### PR TITLE
feat: add agent self-improvement system with memory and skills

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -c \"import ast; ast.parse\\(open\\(''agent/agents/explorer.py''\\).read\\(\\)\\); print\\(''explorer.py: OK''\\)\")",
+      "Bash(python -c \"import ast; ast.parse\\(open\\(''agent/tools/storage.py''\\).read\\(\\)\\); print\\(''storage.py: OK''\\)\")",
+      "Bash(docker ps:*)",
+      "Bash(docker exec:*)",
+      "Bash(Get-Content \"database\\\\migrations\\\\007_app_memory.sql\")"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,20 +36,27 @@ Frontend → Backend API → Redis Queue (BullMQ + raw list)
                         Python Worker (main.py)
                                 ↓
                         LangGraph Agent Pipeline
-                        (orchestrator → explorer → validator → [security/reporter])
+                        (orchestrator → explorer → validator → security → reporter)
                                 ↓
-                        PostgreSQL (bugs_found, screenshots, reports)
+                        PostgreSQL (test_runs.summary JSON, bug_reports, app_memory)
                                 ↓
                         Backend API → Frontend (user views results)
 ```
 
 ### Agent Pipeline Flow
 
-- **OrchestratorAgent**: Analyzes target URL, plans test strategy
-- **ExplorerAgent**: Uses Playwright to navigate the app, takes screenshots
-- **ValidatorAgent**: Reviews screenshots/logs to find functional bugs
-- **SecurityAgent**: Runs active security tests (XSS, SQL injection, auth bypass)
-- **ReporterAgent**: Structures bug findings into reports
+Linear pipeline — every run executes all five agents in order.
+
+- **OrchestratorAgent**: LLM produces JSON strategic plan (`strategic_plan`); parsed via `tools/json_utils.py`
+- **ExplorerAgent**: Playwright exploration; merges plan URLs with memory priority list; sets `visited_urls`; `observe` / `errors_detected` steps for Validator
+- **ValidatorAgent**: LLM on `observe` / `errors_detected` steps; strips screenshot base64 after run
+- **SecurityAgent**: XSS/SQLi/secret scans on seed URL + `visited_urls` (see `SECURITY_MAX_URLS`)
+- **ReporterAgent**: `tools/bug_dedupe.dedupe_bugs` then LLM structured reports; `dedupe_stats` on state
+
+### Frontend (high level)
+
+- Run detail (`BugReports.jsx`): SSE live activity, `AgentPipelineTracker`, `AgentActivityLog`
+- Static `/agents` page: `AgentProfiles.jsx` + `data/agentProfiles.js`
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,10 @@ Frontend → Backend API → Redis Queue (BullMQ + raw list)
 Linear pipeline — every run executes all five agents in order.
 
 - **OrchestratorAgent**: LLM produces JSON strategic plan (`strategic_plan`); parsed via `tools/json_utils.py`
-- **ExplorerAgent**: Playwright exploration; merges plan URLs with memory priority list; sets `visited_urls`; `observe` / `errors_detected` steps for Validator
-- **ValidatorAgent**: LLM on `observe` / `errors_detected` steps; strips screenshot base64 after run
-- **SecurityAgent**: XSS/SQLi/secret scans on seed URL + `visited_urls` (see `SECURITY_MAX_URLS`)
-- **ReporterAgent**: `tools/bug_dedupe.dedupe_bugs` then LLM structured reports; `dedupe_stats` on state
+- **ExplorerAgent**: Playwright exploration; merges plan URLs with memory priority list; sets `visited_urls`; `observe` / `errors_detected` steps for Validator; **form fuzzing** (edge-case payloads), **performance checks** (Navigation Timing API), **accessibility audits** (alt text, labels, headings, lang)
+- **ValidatorAgent**: Text-based LLM analysis of `observe` / `errors_detected` steps + **multimodal vision analysis** of screenshots for visual bugs; regression detection via `app_memory.known_bugs`; strips screenshot base64 after run
+- **SecurityAgent**: XSS/SQLi/secret scans on seed URL + `visited_urls` (see `SECURITY_MAX_URLS`); **adaptive payloads** from memory + skills; **HTTP header**, **cookie security**, and **CSRF** checks
+- **ReporterAgent**: `tools/bug_dedupe.dedupe_bugs` (fingerprint + **semantic similarity**) then LLM structured reports; regression tagging; `dedupe_stats` on state
 
 ### Frontend (high level)
 
@@ -69,7 +69,7 @@ Linear pipeline — every run executes all five agents in order.
 | **Job Queue** | Redis + BullMQ | Backend enqueues via BullMQ; Python worker polls raw Redis list |
 | **Backend** | Express + Node.js | PostgreSQL driver (`pg`), bcrypt for auth, JWT tokens |
 | **Frontend** | React + Vite | React Router for routing, Axios for API calls |
-| **Database** | PostgreSQL 15 | Tables: `users`, `apps`, `test_runs`, `bug_reports` |
+| **Database** | PostgreSQL 15 | Tables: `users`, `apps`, `test_runs`, `bug_reports`, `app_memory`, `agent_skills` |
 
 ---
 
@@ -87,7 +87,12 @@ psql postgresql://postgres:postgres@localhost:5432/bughunter \
   -f database/migrations/001_users.sql \
   -f database/migrations/002_apps.sql \
   -f database/migrations/003_test_runs.sql \
-  -f database/migrations/004_bug_reports.sql
+  -f database/migrations/004_bug_reports.sql \
+  -f database/migrations/005_not_null_constraints.sql \
+  -f database/migrations/006_credentials_text.sql \
+  -f database/migrations/007_app_memory.sql \
+  -f database/migrations/007_agent_memory.sql \
+  -f database/migrations/008_run_status_enum.sql
 
 # Windows (PowerShell):
 Get-Content database\migrations\001_users.sql | docker exec -i bughunter-postgres psql -U postgres -d bughunter
@@ -159,10 +164,14 @@ npm run preview # Preview production build
   - `reporter.py` - Structures findings into bug reports
 - **tools/screenshot.py** - Playwright screenshot capture and base64 encoding
 - **tools/storage.py** - S3 upload for screenshots (optional)
+- **tools/memory.py** - Per-app memory load/save, fingerprinting, page priority, skill extraction
+- **tools/bug_dedupe.py** - Semantic + fingerprint bug deduplication
+- **tools/control.py** - Redis-based run control signals (stop/pause/resume)
 
 ### Backend (`backend/src/`)
-- **index.js** - Express app setup; mounts routes, error handlers
+- **index.js** - Express app setup; mounts routes, error handlers, rate limiting, request logging
 - **queue/testQueue.js** - BullMQ Queue + raw Redis list for Python worker communication
+- **jobs/staleRunReaper.js** - Background reaper for ghost runs (heartbeat-based)
 - **config/db.js** - PostgreSQL connection pool
 - **config/redis.js** - Redis client
 - **middleware/auth.js** - JWT verification middleware
@@ -172,8 +181,10 @@ npm run preview # Preview production build
 - **routes/** - Express route definitions
 
 ### Frontend (`frontend/src/`)
-- **App.jsx** - Main router; defines Login, Register, ProtectedRoute, and page routes
+- **App.jsx** - Main router; defines Login, Register, ProtectedRoute, and page routes; wrapped in ErrorBoundary + NotificationProvider
 - **context/AuthContext.jsx** - React context for user auth state and login/register functions
+- **context/NotificationContext.jsx** - Global toast notification system (useNotification hook)
+- **components/ErrorBoundary.jsx** - React error boundary with recovery UI
 - **components/**:
   - `Dashboard.jsx` - Home page (quick stats)
   - `AppList.jsx` - CRUD for registered apps
@@ -214,16 +225,26 @@ Set `LLM_PROVIDER` in `agent/.env`. Each provider requires its API key:
 All agents receive/return `AgentState` (TypedDict in `graph/state.py`):
 ```python
 {
+  'run_id': str,
   'url': str,
   'credentials': Optional[Dict],
   'current_page': Optional[str],
-  'screenshots': List[Dict],  # {label, base64, url, timestamp}
-  'bugs_found': List[Dict],   # raw observations
-  'test_steps': List[Dict],   # {action, selector, value, result}
+  'screenshots': List[Dict],      # {label, base64, url, timestamp, local_path}
+  'screenshot_paths': List[str],
+  'bugs_found': List[Dict],       # raw observations
+  'test_steps': List[Dict],       # {action, selector, value, result}
   'current_agent': Optional[str],
   'error': Optional[str],
   'status': str,
-  'report': Optional[List[Dict]]  # final structured report
+  'test_config': Optional[Dict],
+  'report': Optional[List[Dict]], # final structured report
+  'app_memory': Dict,             # per-app memory blob (known bugs, page scores, login steps)
+  'skills': List[Dict],           # agent skills from agent_skills table
+  'app_id': Optional[str],
+  'login_steps_for_memory': Optional[List],
+  'strategic_plan': Optional[Dict],
+  'visited_urls': Optional[List[str]],
+  'dedupe_stats': Optional[Dict],
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,16 +49,13 @@ BugHunter.AI is a fully automated bug-detection platform that deploys a multi-ag
 
 ### Agent Flow
 
+All five agents run in a **fixed linear order** (no branching on bug count):
+
 ```
-orchestrator ──▶ explorer ──▶ validator ──▶ [has_bugs?]
-                                                │
-                              ┌─────────────────┴──────────────────┐
-                              ▼ yes                                  ▼ no
-                           reporter ◀────── security ◀──────────────┘
-                              │
-                              ▼
-                             END
+orchestrator ──▶ explorer ──▶ validator ──▶ security ──▶ reporter ──▶ END
 ```
+
+The orchestrator emits a **strategic plan** (JSON: pages, journeys, focus areas) that the Explorer uses for URL priority and LLM prompts. The Explorer records **visited URLs**; Security runs XSS/SQLi/secret checks across those URLs (capped). The Reporter **deduplicates** raw findings before generating structured reports.
 
 ---
 
@@ -74,6 +71,16 @@ orchestrator ──▶ explorer ──▶ validator ──▶ [has_bugs?]
 | Queue       | Redis 7 + BullMQ                                                  |
 | Storage     | AWS S3 (screenshots)                                              |
 | Auth        | JWT (bcrypt + jsonwebtoken)                                       |
+
+---
+
+## 📚 Documentation
+
+| Document | Contents |
+|----------|----------|
+| [documents/TECHNICAL_SPEC.md](documents/TECHNICAL_SPEC.md) | Full system spec: frontend routes, agent pipeline, DB summary fields, env vars |
+| [docs/testing-guide.md](docs/testing-guide.md) | End-to-end: register apps, run tests, interpret the UI |
+| [CLAUDE.md](CLAUDE.md) | Short architecture reference for AI-assisted development |
 
 ---
 
@@ -291,19 +298,19 @@ Since these are branching flows, register the app **twice** — once for each us
 ## 🤖 Agent Descriptions
 
 ### OrchestratorAgent
-Analyzes the target app URL, plans the testing strategy, identifies key user flows, and initializes the state for downstream agents. Uses the configured LLM to generate a structured test plan.
+Analyzes the target URL, credentials, app memory, and `test_config`. Produces **JSON** (`pages`, `user_journeys`, `focus_areas`, `notes`) stored as **`strategic_plan`** and used by the Explorer for URL priority and prompts.
 
 ### ExplorerAgent
-Uses Playwright to navigate the web application with `domcontentloaded` wait strategy for reliable page loading. At each page, it takes a screenshot, asks the LLM what to test, performs actions (clicks, form fills, navigation), captures console/network errors, and logs all steps. Explores up to 5 pages per run.
+Playwright navigation (`domcontentloaded`). Merges **strategic plan URLs** with memory-driven bug-prone pages. Per page: screenshot, LLM “what to test” (plan-aware), `observe` / `errors_detected` steps. Records **`visited_urls`** for Security. Page cap: `AGENT_MAX_PAGES` / `test_config.max_pages` (default 5).
 
 ### ValidatorAgent
-Reviews screenshots and interaction logs. Asks the LLM to identify bugs including 404s, broken layouts, JavaScript errors, incorrect data display, and failed form validations.
+Iterates `test_steps` with `action` in `observe` or `errors_detected` and asks the LLM to list functional/UI/data issues. Strips screenshot `base64` from state after validation.
 
 ### SecurityAgent
-Performs active security testing: XSS injection (5 payloads), SQL injection attempts (5 payloads), authentication bypass tests, and source code inspection for exposed secrets (API keys, passwords, AWS credentials).
+Runs XSS/SQLi/secret scans on the **seed URL plus `visited_urls`**, deduped and capped by **`SECURITY_MAX_URLS`** (default 6). One browser session per target URL.
 
 ### ReporterAgent
-Takes the `bugs_found` list and uses the LLM to generate structured bug reports with title, description, reproduction steps, expected/actual behavior, and severity classification (critical/high/medium/low).
+**Deduplicates** raw `bugs_found` by fingerprint, then uses the LLM to produce structured reports (title, description, steps, severity, regression vs app memory).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,12 @@ psql postgresql://postgres:postgres@localhost:5432/bughunter \
   -f database/migrations/001_users.sql \
   -f database/migrations/002_apps.sql \
   -f database/migrations/003_test_runs.sql \
-  -f database/migrations/004_bug_reports.sql
+  -f database/migrations/004_bug_reports.sql \
+  -f database/migrations/005_not_null_constraints.sql \
+  -f database/migrations/006_credentials_text.sql \
+  -f database/migrations/007_app_memory.sql \
+  -f database/migrations/007_agent_memory.sql \
+  -f database/migrations/008_run_status_enum.sql
 ```
 
 **Windows (PowerShell):**
@@ -301,16 +306,67 @@ Since these are branching flows, register the app **twice** — once for each us
 Analyzes the target URL, credentials, app memory, and `test_config`. Produces **JSON** (`pages`, `user_journeys`, `focus_areas`, `notes`) stored as **`strategic_plan`** and used by the Explorer for URL priority and prompts.
 
 ### ExplorerAgent
-Playwright navigation (`domcontentloaded`). Merges **strategic plan URLs** with memory-driven bug-prone pages. Per page: screenshot, LLM “what to test” (plan-aware), `observe` / `errors_detected` steps. Records **`visited_urls`** for Security. Page cap: `AGENT_MAX_PAGES` / `test_config.max_pages` (default 5).
+Playwright navigation (`domcontentloaded`). Merges **strategic plan URLs** with memory-driven bug-prone pages. Per page: screenshot, LLM “what to test” (plan-aware), `observe` / `errors_detected` steps. Records **`visited_urls`** for Security. Page cap: `AGENT_MAX_PAGES` / `test_config.max_pages` (default 5). Also runs **form fuzzing** (edge-case payloads: empty, long strings, unicode, special characters, script tags, SQL quotes), **performance checks** (Navigation Timing API: load time, TTFB), and **accessibility audits** (missing alt text, unlabeled inputs, inaccessible buttons, heading level skips, missing lang attribute).
 
 ### ValidatorAgent
-Iterates `test_steps` with `action` in `observe` or `errors_detected` and asks the LLM to list functional/UI/data issues. Strips screenshot `base64` from state after validation.
+Iterates `test_steps` with `action` in `observe` or `errors_detected` and asks the LLM to list functional/UI/data issues. **Vision analysis** sends screenshots as multimodal images to the LLM, detecting visual bugs like broken layouts, missing images, text overflow, and misalignment. Checks known bugs from `app_memory` for regression detection. Strips screenshot `base64` from state after validation.
 
 ### SecurityAgent
-Runs XSS/SQLi/secret scans on the **seed URL plus `visited_urls`**, deduped and capped by **`SECURITY_MAX_URLS`** (default 6). One browser session per target URL.
+Runs XSS/SQLi/secret scans on the **seed URL plus `visited_urls`**, deduped and capped by **`SECURITY_MAX_URLS`** (default 6). Uses **adaptive payloads** from app memory and skills to prioritize previously effective attack vectors. Also checks **HTTP security headers** (HSTS, CSP, X-Frame-Options, X-Content-Type-Options), **cookie security** (HttpOnly, Secure, SameSite flags), and **CSRF protection** (form token detection).
 
 ### ReporterAgent
-**Deduplicates** raw `bugs_found` by fingerprint, then uses the LLM to produce structured reports (title, description, steps, severity, regression vs app memory).
+**Deduplicates** raw `bugs_found` using both fingerprint matching and **semantic similarity** (title/description similarity >= 0.70 via SequenceMatcher), then uses the LLM to produce structured reports (title, description, steps, severity, regression vs app memory).
+
+---
+
+## 🧠 Agent Self-Improvement
+
+BugHunter.AI features a **dual memory system** that makes agents smarter with each consecutive run:
+
+### App Memory (`app_memory` table)
+Per-app JSONB blob that persists across runs. Stores:
+- **Known bugs** with fingerprints (SHA-256 of title + page_url) for regression detection
+- **Page priority scores** — bug-prone pages get higher exploration priority
+- **Login steps** — successful login flows are replayed on subsequent runs
+- **Run metadata** — total runs, timestamps, navigation maps
+
+### Agent Skills (`agent_skills` table)
+Structured skill records learned from successful runs:
+- **Bug patterns** — page_url-to-bug_type mappings with confidence scores
+- **Effective security payloads** — XSS/SQLi payloads that found real vulnerabilities
+- Skills are **app-specific** or **global** (shared across all apps)
+- Confidence increases (+0.1) each time a skill proves effective
+
+### How It Works
+1. Before each run, memory and skills are loaded and injected into agent state
+2. **Orchestrator** uses memory to inform strategic planning
+3. **Explorer** prioritizes bug-prone pages from memory
+4. **Security** uses adaptive payloads from skills
+5. **Validator** checks against known bugs for regression detection
+6. **Reporter** tags bugs as regressions if fingerprints match known bugs
+7. After a successful run, memory is updated and new skills are extracted
+
+---
+
+## 🛡️ Backend Reliability
+
+| Feature | Description |
+|---------|-------------|
+| **Global Rate Limiting** | 100 requests per 15 minutes per IP on all `/api/` routes (configurable via `RATE_LIMIT_MAX`) |
+| **Queue Heartbeat** | Agent writes a Redis heartbeat every 30s while processing a run |
+| **Stale Run Reaper** | Backend checks every 60s for "running" jobs with expired heartbeats and marks them as failed |
+| **Structured Logging** | JSON-formatted request logs with method, path, status, duration, IP |
+| **Deep Health Check** | `/health` endpoint verifies DB and Redis connectivity, returns uptime |
+| **Request Logging** | Every request logged with duration and status code classification |
+
+---
+
+## 🎨 Frontend Resilience
+
+| Feature | Description |
+|---------|-------------|
+| **Error Boundary** | React class component catches render errors with a recovery UI (Try Again / Reload) |
+| **Toast Notifications** | Global notification system via `useNotification()` hook — success, error, warning, info toasts with auto-dismiss |
 
 ---
 
@@ -364,6 +420,18 @@ users ──────────────── apps ──────�
                         │ updated_at             │ summary       │ status
                                                  │ error         │ screenshot_url
                                                  │ created_at    │ page_url
+
+app_memory ─────────── agent_skills
+  │                       │
+  │ app_id (FK, PK)       │ id (UUID PK)
+  │ data (JSONB)          │ app_id (FK, nullable)
+  │ updated_at            │ agent_type
+                          │ skill_type
+                          │ description
+                          │ skill_data (JSONB)
+                          │ confidence (float)
+                          │ times_used / times_effective
+                          │ created_at / updated_at
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -249,6 +249,45 @@ Open http://localhost:5173
 
 ---
 
+## 📋 Registering an App with Multi-Step / SSO Login
+
+Some apps use an **email-first authentication flow** where the next step depends on the user type:
+- **Non-SSO users**: Email → password page → app
+- **SSO users**: Email → redirect to Identity Provider (IDP) → back to app
+
+Since these are branching flows, register the app **twice** — once for each user path — using **SSO / Multi-Step** auth mode.
+
+### Non-SSO User (email → password page → listing)
+
+| Step | Action | Selector | Value |
+|------|--------|----------|-------|
+| 1 | Fill input | `input[type="email"]` | `user@example.com` |
+| 2 | Click element | `button[type="submit"]` | *(leave blank)* |
+| 3 | Wait for element | `input[type="password"]` | timeout: 10000 |
+| 4 | Fill input | `input[type="password"]` | `yourpassword` |
+| 5 | Click element | `button[type="submit"]` | *(leave blank)* |
+| 6 | Wait for redirect | *(no selector)* | timeout: 15000 |
+
+### SSO User (email → IDP redirect → listing)
+
+| Step | Action | Selector | Value |
+|------|--------|----------|-------|
+| 1 | Fill input | `input[type="email"]` | `ssouser@company.com` |
+| 2 | Click element | `button[type="submit"]` | *(leave blank)* |
+| 3 | Wait for redirect | *(no selector)* | timeout: 15000 |
+| 4 | Fill input | IDP's email/username field | `ssouser@company.com` |
+| 5 | Fill input | `input[type="password"]` | `idppassword` |
+| 6 | Click element | `button[type="submit"]` | *(leave blank)* |
+| 7 | Wait for redirect | *(no selector)* | timeout: 20000 |
+
+**Tips:**
+- Use browser DevTools (F12 → Inspector) to find the exact CSS selectors for each field.
+- `Wait for element` before the password field ensures the agent waits for the second page to load.
+- `Wait for redirect` with a generous timeout (15–20s) handles slow IDP redirects.
+- Name apps clearly, e.g. `"MyApp - Standard Login"` and `"MyApp - SSO Login"`, so you can run targeted tests on each flow.
+
+---
+
 ## 🤖 Agent Descriptions
 
 ### OrchestratorAgent

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -44,6 +44,8 @@ AGENT_API_SECRET=change-me-in-production
 # ── Agent tuning ─────────────────────────────────────────────────────────
 # Max pages to explore per run (default: 5)
 # AGENT_MAX_PAGES=5
+# Max URLs to run XSS/SQLi/secret scans on (seed URL + explorer visits; default: 6)
+# SECURITY_MAX_URLS=6
 
 # ── Storage (for screenshots, optional) ──────────────────────────────────
 # Leave these unset to store screenshots locally only

--- a/agent/agents/explorer.py
+++ b/agent/agents/explorer.py
@@ -350,6 +350,187 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
 
         return shots
 
+    # ── Form Fuzzing ──────────────────────────────────────────────────────────
+    FUZZ_PAYLOADS = [
+        ("empty", ""),
+        ("long_string", "A" * 5000),
+        ("special_chars", "!@#$%^&*()_+-=[]{}|;':\",./<>?`~"),
+        ("unicode", "测试 émojis 🐛 Ñoño"),
+        ("negative_number", "-99999"),
+        ("script_tag", "<script>alert(1)</script>"),
+        ("sql_quote", "' OR '1'='1"),
+    ]
+
+    def _fuzz_forms(self, page_url: str, run_id: str) -> list:
+        """Test form inputs with edge-case values and record any errors."""
+        bugs = []
+        try:
+            inputs = self.browser.get_form_inputs()
+            if not inputs:
+                return bugs
+
+            # Test up to 3 inputs with up to 3 payloads each
+            for selector in inputs[:3]:
+                for label, payload in self.FUZZ_PAYLOADS[:3]:
+                    try:
+                        self.browser.fill_form(selector, payload)
+                    except Exception:
+                        continue
+
+                # Try submitting after filling with edge-case data
+                try:
+                    self.browser.click("button[type='submit'], input[type='submit']")
+                    self.browser.page.wait_for_timeout(1000)
+
+                    # Check for errors after submission
+                    console_errors = self.browser.get_console_errors()
+                    source = self.browser.get_page_source().lower()
+
+                    error_indicators = [
+                        "500 internal server error", "unhandled exception",
+                        "traceback", "fatal error", "uncaught typeerror",
+                        "cannot read properties of", "null reference",
+                    ]
+                    for indicator in error_indicators:
+                        if indicator in source:
+                            bugs.append({
+                                "type": "functional",
+                                "title": f"Form crashes with edge-case input on {selector}",
+                                "description": f"Submitting fuzz data to '{selector}' caused a server/client error: '{indicator}' detected in page.",
+                                "page_url": page_url,
+                                "severity": "high",
+                            })
+                            break
+
+                    if console_errors:
+                        js_errors = [e for e in console_errors if "error" in e.lower() or "uncaught" in e.lower()]
+                        if js_errors:
+                            bugs.append({
+                                "type": "error",
+                                "title": f"JS error after form submission on {selector}",
+                                "description": f"Console errors after submitting edge-case data: {js_errors[0][:200]}",
+                                "page_url": page_url,
+                                "severity": "medium",
+                            })
+
+                    # Navigate back for next test
+                    self.browser.navigate(page_url)
+                    self.browser.page.wait_for_timeout(500)
+                except Exception:
+                    try:
+                        self.browser.navigate(page_url)
+                    except Exception:
+                        pass
+        except Exception as exc:
+            logger.debug(f"Form fuzzing failed on {page_url}: {exc}")
+        return bugs
+
+    # ── Performance & Accessibility Checks ─────────────────────────────────
+    def _check_performance(self, page_url: str) -> list:
+        """Check page load performance metrics via Playwright."""
+        bugs = []
+        try:
+            metrics = self.browser.page.evaluate("""
+                () => {
+                    const perf = performance.getEntriesByType('navigation')[0];
+                    if (!perf) return null;
+                    return {
+                        dom_content_loaded: Math.round(perf.domContentLoadedEventEnd - perf.startTime),
+                        load_complete: Math.round(perf.loadEventEnd - perf.startTime),
+                        ttfb: Math.round(perf.responseStart - perf.requestStart),
+                    };
+                }
+            """)
+            if metrics:
+                if metrics.get("load_complete", 0) > 5000:
+                    bugs.append({
+                        "type": "performance",
+                        "title": "Slow page load",
+                        "description": f"Page took {metrics['load_complete']}ms to fully load (threshold: 5000ms). "
+                                       f"TTFB: {metrics.get('ttfb', 0)}ms, DOMContentLoaded: {metrics.get('dom_content_loaded', 0)}ms.",
+                        "page_url": page_url,
+                        "severity": "medium",
+                    })
+                if metrics.get("ttfb", 0) > 2000:
+                    bugs.append({
+                        "type": "performance",
+                        "title": "Slow server response (TTFB)",
+                        "description": f"Time to first byte is {metrics['ttfb']}ms (threshold: 2000ms). Server may be under load or unoptimized.",
+                        "page_url": page_url,
+                        "severity": "medium",
+                    })
+        except Exception as exc:
+            logger.debug(f"Performance check failed on {page_url}: {exc}")
+        return bugs
+
+    def _check_accessibility(self, page_url: str) -> list:
+        """Run basic accessibility checks via DOM inspection."""
+        bugs = []
+        try:
+            a11y_issues = self.browser.page.evaluate("""
+                () => {
+                    const issues = [];
+                    // Images without alt text
+                    const imgs = document.querySelectorAll('img:not([alt])');
+                    if (imgs.length > 0) {
+                        issues.push({type: 'missing_alt', count: imgs.length, detail: 'Images missing alt text'});
+                    }
+                    // Form inputs without labels
+                    const inputs = document.querySelectorAll('input:not([type="hidden"]):not([type="submit"]):not([type="button"])');
+                    let unlabeled = 0;
+                    inputs.forEach(input => {
+                        const id = input.id;
+                        const hasLabel = id && document.querySelector(`label[for="${id}"]`);
+                        const hasAriaLabel = input.getAttribute('aria-label') || input.getAttribute('aria-labelledby');
+                        const hasPlaceholder = input.getAttribute('placeholder');
+                        if (!hasLabel && !hasAriaLabel && !hasPlaceholder) unlabeled++;
+                    });
+                    if (unlabeled > 0) {
+                        issues.push({type: 'unlabeled_input', count: unlabeled, detail: 'Form inputs without labels or aria-labels'});
+                    }
+                    // Buttons without accessible names
+                    const buttons = document.querySelectorAll('button');
+                    let emptyButtons = 0;
+                    buttons.forEach(btn => {
+                        if (!btn.textContent.trim() && !btn.getAttribute('aria-label') && !btn.querySelector('img[alt]')) {
+                            emptyButtons++;
+                        }
+                    });
+                    if (emptyButtons > 0) {
+                        issues.push({type: 'empty_button', count: emptyButtons, detail: 'Buttons without accessible text'});
+                    }
+                    // Missing lang attribute on html
+                    if (!document.documentElement.getAttribute('lang')) {
+                        issues.push({type: 'missing_lang', count: 1, detail: 'HTML element missing lang attribute'});
+                    }
+                    // Low contrast detection (basic: white text on light bg or dark on dark)
+                    // Heading hierarchy check
+                    const headings = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'));
+                    let skippedLevels = 0;
+                    for (let i = 1; i < headings.length; i++) {
+                        const prev = parseInt(headings[i-1].tagName[1]);
+                        const curr = parseInt(headings[i].tagName[1]);
+                        if (curr > prev + 1) skippedLevels++;
+                    }
+                    if (skippedLevels > 0) {
+                        issues.push({type: 'heading_skip', count: skippedLevels, detail: 'Heading levels are skipped (e.g., h1 to h3)'});
+                    }
+                    return issues;
+                }
+            """)
+            for issue in (a11y_issues or []):
+                severity = "medium" if issue["type"] in ("missing_alt", "unlabeled_input") else "low"
+                bugs.append({
+                    "type": "accessibility",
+                    "title": f"Accessibility: {issue['detail']}",
+                    "description": f"Found {issue['count']} instance(s) of {issue['detail']} on this page.",
+                    "page_url": page_url,
+                    "severity": severity,
+                })
+        except Exception as exc:
+            logger.debug(f"Accessibility check failed on {page_url}: {exc}")
+        return bugs
+
     @staticmethod
     def _extract_json(text: str) -> str:
         """Strip markdown fences and extract first JSON object or array from LLM output."""
@@ -532,6 +713,7 @@ Return only the JSON object, no explanation."""
 
         visited_urls = []
         pages_explored = 0
+        bugs_found = list(state.get("bugs_found", []))
         app_memory = state.get("app_memory") or {}
         strategic_plan = state.get("strategic_plan") or {}
         # Bug-prone pages from prior runs — used only to sort discovered links, not to guess URLs
@@ -627,6 +809,34 @@ Return only the JSON object, no explanation."""
                         "action": "page_actions_performed",
                         "detail": f"Executed {len(action_shots)} action(s) on this page",
                     })
+
+                # Performance checks
+                perf_bugs = self._check_performance(current_url)
+                if perf_bugs:
+                    test_steps.append({"agent": "explorer", "url": current_url, "action": "errors_detected",
+                                       "detail": f"Performance issues: {[b['title'] for b in perf_bugs]}"})
+                    for b in perf_bugs:
+                        bugs_found.append(b)
+                        publish_event(run_id, "bug_found", {"title": b["title"], "severity": b["severity"],
+                                                            "page_url": current_url, "message": f"[PERF] {b['title']}"})
+
+                # Accessibility checks
+                a11y_bugs = self._check_accessibility(current_url)
+                if a11y_bugs:
+                    test_steps.append({"agent": "explorer", "url": current_url, "action": "errors_detected",
+                                       "detail": f"Accessibility issues: {[b['title'] for b in a11y_bugs]}"})
+                    for b in a11y_bugs:
+                        bugs_found.append(b)
+
+                # Form fuzzing (edge-case input testing)
+                fuzz_bugs = self._fuzz_forms(current_url, run_id)
+                if fuzz_bugs:
+                    test_steps.append({"agent": "explorer", "url": current_url, "action": "errors_detected",
+                                       "detail": f"Form fuzzing issues: {[b['title'] for b in fuzz_bugs]}"})
+                    for b in fuzz_bugs:
+                        bugs_found.append(b)
+                        publish_event(run_id, "bug_found", {"title": b["title"], "severity": b["severity"],
+                                                            "page_url": current_url, "message": f"[FUZZ] {b['title']}"})
 
                 # -----------------------------------------------------------
                 # Login handling
@@ -834,6 +1044,7 @@ Return only the JSON object, no explanation."""
             "current_agent": "explorer",
             "screenshots": screenshots,
             "test_steps": test_steps,
+            "bugs_found": bugs_found,
             "current_page": visited_urls[-1] if visited_urls else url,
             "login_steps_for_memory": state.get("login_steps_for_memory"),
             "visited_urls": visited_urls,

--- a/agent/agents/explorer.py
+++ b/agent/agents/explorer.py
@@ -14,6 +14,7 @@ from graph.state import AgentState
 from providers import get_llm
 from tools.browser import BrowserTool
 from tools.events import publish_event
+from tools.memory import format_memory_for_prompt
 from tools.screenshot import capture
 
 logger = logging.getLogger("bughunter.explorer")
@@ -29,15 +30,27 @@ class ExplorerAgent:
         self.browser = BrowserTool()
         self._login_done = False
 
-    def _ask_what_to_test(self, page_title: str, page_url: str, source_snippet: str) -> str:
+    def _ask_what_to_test(self, page_title: str, page_url: str, source_snippet: str, memory: dict = None) -> str:
         """Ask the LLM what actions to perform on the current page."""
+        history_note = ""
+        if memory:
+            buggy_pages = memory.get("all_buggy_pages", [])
+            page_history = [p for p in buggy_pages if p.get("url") == page_url]
+            if page_history:
+                p = page_history[0]
+                types = ", ".join(p.get("bug_types", []))
+                history_note = (
+                    f"\nIMPORTANT: This page had {p['bug_count']} bug(s) in previous runs "
+                    f"(types: {types}). Focus testing on those areas and look for regressions.\n"
+                )
+
         prompt = f"""You are a QA automation engineer exploring a web app.
 
 Current page: {page_url}
 Page title: {page_title}
 HTML snippet (first 2000 chars):
 {source_snippet[:2000]}
-
+{history_note}
 List the top 3 actions to perform on this page to discover bugs.
 Format: JSON array of objects with keys: action (click/fill/navigate), selector, value (optional), reason
 """
@@ -122,11 +135,15 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
         url = state["url"]
         run_id = state.get("run_id")
         credentials = state.get("credentials") or {}
+        memory = state.get("memory") or {}
         screenshots = list(state.get("screenshots", []))
         test_steps = list(state.get("test_steps", []))
 
         visited_urls = []
         pages_explored = 0
+
+        # Build set of previously buggy URLs for prioritized exploration
+        buggy_urls = {p["url"] for p in memory.get("all_buggy_pages", []) if p.get("url")}
 
         publish_event(run_id, "agent_start", {"agent": "explorer", "message": "Browser exploration starting…"})
 
@@ -162,8 +179,8 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
 
                 publish_event(run_id, "page_visited", {"url": current_url, "page": pages_explored, "title": page_title, "message": f"Exploring: {current_url}"})
 
-                # Ask the LLM what to test
-                actions_json = self._ask_what_to_test(page_title, current_url, source)
+                # Ask the LLM what to test (with memory context)
+                actions_json = self._ask_what_to_test(page_title, current_url, source, memory)
                 test_steps.append(
                     {
                         "agent": "explorer",
@@ -264,18 +281,20 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
                     )
 
                 # Try to find and click a navigation link to a new page
+                # Prioritize previously buggy pages first
                 navigated = False
                 links = self.browser.get_all_links()
-                for link in links:
-                    if link and link not in visited_urls and link.startswith(url):
-                        try:
-                            self.browser.navigate(link)
-                            self.browser.dismiss_overlays()
-                            visited_urls.append(link)
-                            navigated = True
-                            break
-                        except Exception:
-                            continue
+                candidate_links = [l for l in links if l and l not in visited_urls and l.startswith(url)]
+                priority_links = sorted(candidate_links, key=lambda l: l not in buggy_urls)
+                for link in priority_links:
+                    try:
+                        self.browser.navigate(link)
+                        self.browser.dismiss_overlays()
+                        visited_urls.append(link)
+                        navigated = True
+                        break
+                    except Exception:
+                        continue
 
                 if not navigated:
                     logger.info("No new links found, stopping exploration")

--- a/agent/agents/explorer.py
+++ b/agent/agents/explorer.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import time
+from typing import Optional
 from urllib.parse import urlparse
 
 from langchain_core.messages import HumanMessage
@@ -20,6 +21,7 @@ from langchain_core.messages import HumanMessage
 from graph.state import AgentState
 from providers import get_llm
 from tools.browser import BrowserTool
+from tools.control import SIGNAL_STOP, check_run_control, wait_while_paused
 from tools.events import publish_event
 from tools.screenshot import capture
 
@@ -28,15 +30,33 @@ logger = logging.getLogger("bughunter.explorer")
 MAX_PAGES = int(os.environ.get("AGENT_MAX_PAGES", "5"))  # configurable via env var
 
 
+def _same_origin(a: str, b: str) -> bool:
+    try:
+        return urlparse(a).netloc == urlparse(b).netloc
+    except Exception:
+        return False
+
+
 class ExplorerAgent:
     """Navigates the target web app and collects screenshots + interaction steps."""
 
-    def __init__(self):
+    def __init__(self, extra_blocked_domains: list = None, allowed_domains: list = None):
         self.llm = get_llm()
-        self.browser = BrowserTool()
+        self.browser = BrowserTool(
+            extra_blocked_domains=extra_blocked_domains or [],
+            allowed_domains=allowed_domains or [],
+        )
         self._login_done = False
 
-    def _ask_what_to_test(self, page_title: str, page_url: str, source_snippet: str, instructions: str = "", focus_areas: str = "") -> str:
+    def _ask_what_to_test(
+        self,
+        page_title: str,
+        page_url: str,
+        page_structure: dict,
+        instructions: str = "",
+        focus_areas: str = "",
+        strategic_plan: Optional[dict] = None,
+    ) -> str:
         """Ask the LLM what actions to perform on the current page."""
         custom = ""
         if instructions:
@@ -44,12 +64,76 @@ class ExplorerAgent:
         if focus_areas:
             custom += f"\nFocus areas: {focus_areas}"
 
+        plan_block = ""
+        if strategic_plan:
+            notes = (strategic_plan.get("notes") or "").strip()
+            o_focus = (strategic_plan.get("focus_areas") or "").strip()
+            journeys = strategic_plan.get("user_journeys") or []
+            if notes:
+                plan_block += f"\nOverall strategy notes: {notes[:2000]}"
+            if o_focus:
+                plan_block += f"\nOrchestrator focus_areas: {o_focus}"
+            if journeys:
+                try:
+                    plan_block += f"\nPlanned user journeys: {json.dumps(journeys)[:1500]}"
+                except Exception:
+                    plan_block += f"\nPlanned user journeys: {str(journeys)[:1500]}"
+
+        # Build compact structured context from page_structure dict
+        ctx_parts = []
+        metadata = page_structure.get("metadata") or {}
+        if metadata.get("description"):
+            ctx_parts.append(f"Page description: {metadata['description']}")
+        if metadata.get("headings"):
+            heading_lines = "\n".join(
+                f"  {'#' * h['level']} {h['text']}" for h in metadata["headings"]
+            )
+            ctx_parts.append(f"Page sections:\n{heading_lines}")
+
+        forms = page_structure.get("forms") or []
+        if forms:
+            form_parts = []
+            for i, form in enumerate(forms, 1):
+                field_lines = "\n".join(
+                    f"    - {f['name']} ({f['type']})"
+                    + (f" label={f['label']!r}" if f["label"] else "")
+                    + (" [required]" if f["required"] else "")
+                    + (f" placeholder={f['placeholder']!r}" if f["placeholder"] else "")
+                    for f in form["fields"]
+                )
+                form_parts.append(
+                    f"  Form {i} [{form['method'].upper()} {form['action'] or '(this page)'}]:\n"
+                    + (field_lines or "    (no named fields)")
+                )
+            ctx_parts.append("Forms:\n" + "\n".join(form_parts))
+
+        tables = page_structure.get("tables") or []
+        if tables:
+            tbl_lines = "\n".join(
+                f"  Table {i+1}: columns=[{', '.join(t['headers'])}], rows={t['row_count']}"
+                for i, t in enumerate(tables)
+            )
+            ctx_parts.append(f"Data tables:\n{tbl_lines}")
+
+        kv = page_structure.get("key_values") or {}
+        if kv:
+            kv_lines = "\n".join(f"  {k}: {v}" for k, v in list(kv.items())[:10])
+            ctx_parts.append(f"Key data:\n{kv_lines}")
+
+        if page_structure.get("error"):
+            ctx_parts.append(f"(Page inspection error: {page_structure['error']})")
+        if not ctx_parts:
+            ctx_parts.append("(No structured content detected)")
+
+        structure_block = "\n\n".join(ctx_parts)
+
         prompt = f"""You are a QA automation engineer exploring a web app.
 
 Current page: {page_url}
-Page title: {page_title}{custom}
-HTML snippet (first 2000 chars):
-{source_snippet[:2000]}
+Page title: {page_title}{custom}{plan_block}
+
+Page structure:
+{structure_block}
 
 List the top 3 actions to perform on this page to discover bugs.
 Format: JSON array of objects with keys: action (click/fill/navigate), selector, value (optional), reason
@@ -132,6 +216,141 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
         return any(kw in lower for kw in ("login", "signin", "sign-in", "auth", "sso"))
 
     @staticmethod
+    def _format_steps_for_memory(action_history: list, email: str) -> list:
+        """Convert smart-login action_history to a reusable login-flow format for memory.
+
+        Replaces the actual email value with __EMAIL__ and ensures __PASSWORD__
+        is preserved as a placeholder so credentials are never stored in plaintext.
+        """
+        steps = []
+        for entry in action_history:
+            action = entry.get("action", "")
+            selector = entry.get("selector", "")
+            raw_value = entry.get("raw_value", "")
+
+            step: dict = {"action": action, "selector": selector}
+
+            if "__PASSWORD__" in raw_value:
+                step["value"] = "__PASSWORD__"
+            elif raw_value and raw_value.lower() == email.lower():
+                # LLM sent the actual email; replace with placeholder for safe storage
+                step["value"] = "__EMAIL__"
+            elif raw_value:
+                step["value"] = raw_value
+            # click / navigation actions have no value — omit the key
+
+            steps.append(step)
+        return steps
+
+    def _execute_memory_login(self, steps: list, email: str, password: str):
+        """Execute stored memory login steps, substituting __EMAIL__ and __PASSWORD__.
+
+        Mirrors _execute_login_flow but substitutes placeholders at runtime so
+        credentials are never persisted in plaintext.
+        """
+        for i, step in enumerate(steps):
+            action = step.get("action")
+            selector = step.get("selector", "")
+            raw_value = step.get("value", "")
+            value = raw_value.replace("__PASSWORD__", password).replace("__EMAIL__", email)
+            timeout = step.get("timeout", 15_000)
+
+            logger.info(f"Memory login step {i + 1}/{len(steps)}: {action} '{selector}'")
+            self.browser.dismiss_overlays()
+
+            if action == "fill":
+                self.browser.wait_for_selector(selector, timeout=timeout)
+                self.browser.fill_form(selector, value)
+            elif action == "click":
+                self.browser.wait_for_selector(selector, timeout=timeout)
+                try:
+                    self.browser.click(selector)
+                except Exception:
+                    self.browser.dismiss_overlays()
+                    time.sleep(0.5)
+                    try:
+                        self.browser.click(selector)
+                    except Exception:
+                        self.browser.click(selector, force=True)
+            elif action == "wait_for_navigation":
+                self.browser.wait_for_navigation(timeout=timeout)
+            elif action == "wait_for_selector":
+                self.browser.wait_for_selector(selector, timeout=timeout)
+            elif action == "wait":
+                time.sleep(timeout / 1000)
+
+            logger.debug(f"  → now at: {self.browser.get_current_url()}")
+
+    # Keywords that signal a destructive or session-ending action — never auto-click these.
+    _UNSAFE_CLICK = re.compile(
+        r'\b(delete|remove|reset|clear|logout|sign.?out|close|dismiss|cancel|decline|reject|deactivate|archive)\b',
+        re.I,
+    )
+
+    def _run_page_actions(self, actions_json: str, run_id: str) -> list:
+        """Execute safe LLM-suggested actions (fill / click) on the current page.
+
+        Returns a list of screenshot dicts captured after each successful action.
+        Navigation actions are skipped — the main loop handles page traversal.
+        Destructive-looking clicks are skipped via _UNSAFE_CLICK pattern.
+        """
+        shots = []
+        try:
+            parsed = json.loads(self._extract_json(actions_json))
+            actions = parsed if isinstance(parsed, list) else []
+        except Exception:
+            return shots
+
+        for act in actions[:3]:  # cap at 3 actions per page
+            action = act.get("action", "")
+            selector = act.get("selector", "")
+            value = act.get("value", "") or ""
+            reason = act.get("reason", "")
+
+            if not selector or action == "navigate":
+                continue
+
+            try:
+                if action == "fill" and value:
+                    self.browser.wait_for_selector(selector, timeout=3_000)
+                    self.browser.fill_form(selector, value)
+                    logger.info(f"Executed fill: {selector}")
+
+                elif action == "click":
+                    label = f"{reason} {selector}"
+                    if self._UNSAFE_CLICK.search(label):
+                        logger.debug(f"Skipping unsafe click: {selector}")
+                        continue
+                    self.browser.wait_for_selector(selector, timeout=3_000)
+                    self.browser.click(selector)
+                    logger.info(f"Executed click: {selector}")
+
+                else:
+                    continue
+
+                # Short wait for any JS reactions (modal open, content change, etc.)
+                self.browser.page.wait_for_timeout(800)
+
+                # Capture state after the action
+                try:
+                    shot = capture(self.browser.page, label=f"action_{action}_{selector[:20]}", run_id=run_id)
+                    shot["action_performed"] = f"{action}: {selector}"
+                    shots.append(shot)
+                except Exception:
+                    pass
+
+                publish_event(run_id, "page_action", {
+                    "action": action,
+                    "selector": selector,
+                    "message": f"Performed {action} on {selector}",
+                })
+
+            except Exception as exc:
+                logger.debug(f"Action {action} on '{selector}' failed: {exc}")
+
+        return shots
+
+    @staticmethod
     def _extract_json(text: str) -> str:
         """Strip markdown fences and extract first JSON object or array from LLM output."""
         text = re.sub(r"```(?:json)?\s*", "", text).strip().rstrip("`").strip()
@@ -148,14 +367,28 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
                             return text[idx:i + 1]
         return text
 
-    def _smart_login(self, email: str, password: str) -> bool:
+    def _smart_login(
+        self,
+        email: str,
+        password: str,
+        run_id: str = None,
+        capture_steps: bool = True,
+    ) -> tuple[bool, list, list]:
         """Use the LLM iteratively to navigate any login flow (single-page, email-first, SSO).
 
         The password is never sent to the LLM — a placeholder is used and substituted
         locally before each browser action.
+
+        Returns:
+            (success, step_screenshots, action_history)
+            step_screenshots: list of screenshot dicts when capture_steps=True
+            action_history: list of {action, selector, raw_value, display_value} dicts
+                            used to reconstruct the working flow for memory storage
         """
         MAX_STEPS = 12
         PASSWORD_PLACEHOLDER = "__PASSWORD__"
+        action_history: list[dict] = []
+        step_screenshots: list[dict] = []
 
         for step_num in range(MAX_STEPS):
             self.browser.dismiss_overlays()
@@ -164,16 +397,26 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
             # After the first step, if we've left all auth pages the login succeeded
             if step_num > 0 and not self._is_login_page(current_url):
                 logger.info(f"Smart login: URL is no longer an auth page ({current_url}) — success")
-                return True
+                return True, step_screenshots, action_history
 
             source = self.browser.get_page_source()
+
+            history_str = ""
+            if action_history:
+                lines = "\n".join(
+                    f"  {i+1}. {a['action']} selector='{a.get('selector','')}'"
+                    + (f" value='{a['display_value']}'" if a.get('display_value') else "")
+                    for i, a in enumerate(action_history)
+                )
+                history_str = f"\n\nActions already performed (do NOT repeat these unless the page changed):\n{lines}"
+
             prompt = f"""You are automating login for a web app.
 Current URL: {current_url}
 User email: {email}
 HTML (first 3000 chars):
-{source[:3000]}
+{source[:3000]}{history_str}
 
-Determine the single next action to take to progress the login.
+Determine the single NEXT action to take to progress the login.
 If login appears complete (you are past all login/auth pages), return {{"done": true}}.
 Otherwise return exactly ONE action as a JSON object:
 {{
@@ -193,11 +436,11 @@ Return only the JSON object, no explanation."""
 
             if step.get("done"):
                 logger.info("Smart login: LLM signalled login complete")
-                return True
+                return True, step_screenshots, action_history
 
             action = step.get("action")
             selector = step.get("selector", "")
-            value = step.get("value", "").replace(PASSWORD_PLACEHOLDER, password)
+            value = (step.get("value") or "").replace(PASSWORD_PLACEHOLDER, password)
 
             logger.info(f"Smart login step {step_num + 1}/{MAX_STEPS}: {action} '{selector}'")
 
@@ -214,6 +457,40 @@ Return only the JSON object, no explanation."""
                     self.browser.wait_for_selector(selector, timeout=10000)
                 else:
                     logger.warning(f"Smart login: unknown action '{action}', skipping")
+                    continue
+
+                # Record what was done so the next prompt doesn't repeat it.
+                # raw_value preserves the LLM-provided value (with __PASSWORD__ placeholder)
+                # so we can reconstruct a reusable login flow for memory storage.
+                raw_value = step.get("value") or ""
+                display_value = "(password)" if PASSWORD_PLACEHOLDER in raw_value else raw_value
+                action_history.append({
+                    "action": action,
+                    "selector": selector,
+                    "raw_value": raw_value,
+                    "display_value": display_value,
+                })
+
+                # Capture screenshot after this step and publish event
+                shot = None
+                if capture_steps:
+                    try:
+                        shot = capture(self.browser.page, label=f"login_step_{step_num + 1}", run_id=run_id)
+                        shot["login_step"] = step_num + 1
+                        shot["login_action"] = action
+                        shot["login_selector"] = selector
+                        step_screenshots.append(shot)
+                    except Exception as cap_exc:
+                        logger.debug(f"Smart login: screenshot capture failed at step {step_num + 1}: {cap_exc}")
+
+                publish_event(run_id, "login_step", {
+                    "step": step_num + 1,
+                    "action": action,
+                    "selector": selector,
+                    "screenshot_file": os.path.basename(shot["local_path"]) if shot and shot.get("local_path") else None,
+                    "message": f"Login step {step_num + 1}: {action} → {selector}",
+                })
+
             except Exception as exc:
                 logger.warning(f"Smart login: step {step_num + 1} failed ({exc}), retrying after overlay dismiss")
                 self.browser.dismiss_overlays()
@@ -222,11 +499,19 @@ Return only the JSON object, no explanation."""
                         self.browser.click(selector, force=True)
                     elif action == "fill":
                         self.browser.fill_form(selector, value)
+                    action_history.append({"action": action, "selector": selector, "raw_value": "", "display_value": ""})
+                    publish_event(run_id, "login_step", {
+                        "step": step_num + 1,
+                        "action": action,
+                        "selector": selector,
+                        "screenshot_file": None,
+                        "message": f"Login step {step_num + 1} (retry): {action} → {selector}",
+                    })
                 except Exception:
                     break
 
         logger.warning("Smart login: max steps reached without confirmed success")
-        return False
+        return False, step_screenshots, action_history
 
     def run(self, state: AgentState) -> AgentState:
         url = state["url"]
@@ -239,6 +524,7 @@ Return only the JSON object, no explanation."""
         max_pages = int(test_config.get("max_pages") or MAX_PAGES)
         instructions = test_config.get("instructions", "").strip()
         focus_areas = test_config.get("focus_areas", "").strip()
+        capture_login_steps = test_config.get("screenshot_login_steps", True)
 
         # Use scheme+host for link filtering so post-login pages are explored
         _parsed = urlparse(url)
@@ -246,6 +532,10 @@ Return only the JSON object, no explanation."""
 
         visited_urls = []
         pages_explored = 0
+        app_memory = state.get("app_memory") or {}
+        strategic_plan = state.get("strategic_plan") or {}
+        # Bug-prone pages from prior runs — used only to sort discovered links, not to guess URLs
+        memory_priority_scores = app_memory.get("pages", {})
 
         publish_event(run_id, "agent_start", {"agent": "explorer", "message": "Browser exploration starting…"})
 
@@ -259,44 +549,89 @@ Return only the JSON object, no explanation."""
         try:
             self.browser.start()
 
-            # Navigate to the root URL
+            # Navigate to the starting URL
             self.browser.navigate(url)
             visited_urls.append(url)
-
-            # Dismiss any overlays / cookie consent banners.
-            # Wait briefly for late-loading consent popups (e.g. TrustArc)
-            # before attempting dismissal.
-            time.sleep(2)
+            # Wait for SPA frameworks to render initial content + late-loading consent popups
+            self.browser.page.wait_for_timeout(2_000)
             self.browser.dismiss_overlays()
 
             for _ in range(max_pages):
+                # Check for stop/pause signal before processing each page
+                signal = check_run_control(run_id)
+                if signal == SIGNAL_STOP:
+                    logger.info(f"Stop signal received — ending exploration early after {pages_explored} page(s)")
+                    publish_event(run_id, "run_stopped", {"message": "Test run stopped by user"})
+                    break
+                elif signal is not None:  # pause
+                    publish_event(run_id, "run_paused", {"message": "Test run paused — waiting for resume…"})
+                    stopped_during_pause = wait_while_paused(run_id)
+                    if stopped_during_pause:
+                        logger.info(f"Stop signal received while paused — ending exploration")
+                        publish_event(run_id, "run_stopped", {"message": "Test run stopped by user"})
+                        break
+                    publish_event(run_id, "run_resumed", {"message": "Test run resumed"})
+
                 pages_explored += 1
                 current_url = self.browser.get_current_url()
                 page_title = self.browser.get_title()
-                source = self.browser.get_page_source()
+                page_structure = self.browser.inspect_page_structure()
 
                 # Capture screenshot
-                shot = capture(self.browser.page, label=f"page_{pages_explored}")
+                shot = capture(self.browser.page, label=f"page_{pages_explored}", run_id=run_id)
                 screenshots.append(shot)
 
                 publish_event(run_id, "page_visited", {"url": current_url, "page": pages_explored, "title": page_title, "message": f"Exploring: {current_url}"})
 
-                # Ask the LLM what to test
-                actions_json = self._ask_what_to_test(page_title, current_url, source, instructions, focus_areas)
+                merged_focus = focus_areas
+                if strategic_plan.get("focus_areas") and not merged_focus:
+                    merged_focus = str(strategic_plan.get("focus_areas", "")).strip()
+
+                # Ask the LLM what to test (guided by orchestrator strategic plan)
+                actions_json = self._ask_what_to_test(
+                    page_title,
+                    current_url,
+                    page_structure,
+                    instructions,
+                    merged_focus,
+                    strategic_plan=strategic_plan if strategic_plan else None,
+                )
+                load_time_ms = self.browser.get_page_load_time()
+                api_calls = self.browser.get_api_response_times()
+                page_links = self.browser.get_all_links()
+                same_origin_links = [lnk for lnk in page_links if lnk.startswith(base_origin)]
+                interactive_elements = self.browser.get_clickable_elements()
+
                 test_steps.append(
                     {
                         "agent": "explorer",
                         "url": current_url,
                         "action": "observe",
                         "detail": actions_json,
+                        "page_structure": page_structure,
                         "screenshot_label": shot["label"],
+                        "load_time_ms": load_time_ms,
+                        "links_found": len(same_origin_links),
+                        "api_calls": api_calls,
+                        "interactive_elements": interactive_elements,
                     }
                 )
+
+                # Execute the LLM-suggested actions on this page (safe fills + clicks only)
+                action_shots = self._run_page_actions(actions_json, run_id)
+                if action_shots:
+                    screenshots.extend(action_shots)
+                    test_steps.append({
+                        "agent": "explorer",
+                        "url": current_url,
+                        "action": "page_actions_performed",
+                        "detail": f"Executed {len(action_shots)} action(s) on this page",
+                    })
 
                 # -----------------------------------------------------------
                 # Login handling
                 # -----------------------------------------------------------
-                # Option A: Multi-step SSO/IDP login flow
+                # Option A: Multi-step SSO/IDP login flow (user-provided)
                 if (
                     credentials
                     and "login_flow" in credentials
@@ -323,9 +658,11 @@ Return only the JSON object, no explanation."""
                             }
                         )
 
-                        # Capture post-login screenshot
-                        post_shot = capture(self.browser.page, label="post_login")
+                        # Capture post-login screenshot, then let the next
+                        # loop iteration process the post-login page properly
+                        post_shot = capture(self.browser.page, label="post_login", run_id=run_id)
                         screenshots.append(post_shot)
+                        continue
 
                     except Exception as e:
                         logger.warning(f"Login flow failed: {e}")
@@ -338,45 +675,95 @@ Return only the JSON object, no explanation."""
                             }
                         )
 
-                # Option B: Smart LLM-driven login (handles email-first, SSO redirects, single-page)
                 elif (
                     credentials
                     and "login_flow" not in credentials
                     and not self._login_done
                     and self._is_login_page(current_url)
                 ):
-                    try:
-                        success = self._smart_login(
-                            credentials.get("username", ""),
-                            credentials.get("password", ""),
-                        )
-                        self._login_done = True
-                        test_steps.append(
-                            {
-                                "agent": "explorer",
-                                "action": "smart_login_completed" if success else "smart_login_partial",
-                                "url": current_url,
-                                "detail": (
-                                    f"Smart login {'succeeded' if success else 'reached max steps'}, "
-                                    f"now at {self.browser.get_current_url()}"
-                                ),
-                            }
-                        )
-                        post_login_url = self.browser.get_current_url()
-                        if post_login_url not in visited_urls:
-                            visited_urls.append(post_login_url)
-                        post_shot = capture(self.browser.page, label="post_login")
-                        screenshots.append(post_shot)
-                    except Exception as e:
-                        logger.warning(f"Smart login failed: {e}")
-                        test_steps.append(
-                            {
-                                "agent": "explorer",
-                                "action": "smart_login_failed",
-                                "url": current_url,
-                                "detail": str(e),
-                            }
-                        )
+                    email = credentials.get("username", "")
+                    password = credentials.get("password", "")
+
+                    # Option B0: Memory-based login (skip LLM discovery on runs 2+)
+                    stored_steps = app_memory.get("login", {}).get("working_steps", [])
+                    failure_count = app_memory.get("login", {}).get("failure_count", 0)
+                    memory_login_succeeded = False
+
+                    if stored_steps and failure_count < 3:
+                        try:
+                            logger.info(
+                                f"Attempting memory-based login ({len(stored_steps)} stored steps)"
+                            )
+                            self._execute_memory_login(stored_steps, email, password)
+                            if not self._is_login_page(self.browser.get_current_url()):
+                                memory_login_succeeded = True
+                                self._login_done = True
+                                test_steps.append(
+                                    {
+                                        "agent": "explorer",
+                                        "action": "memory_login_completed",
+                                        "url": current_url,
+                                        "detail": (
+                                            f"Memory login succeeded using {len(stored_steps)} stored steps, "
+                                            f"now at {self.browser.get_current_url()}"
+                                        ),
+                                    }
+                                )
+                                post_shot = capture(self.browser.page, label="post_login", run_id=run_id)
+                                screenshots.append(post_shot)
+                                # Don't add post_login_url to visited_urls here —
+                                # the next loop iteration will process the post-login page properly
+                            else:
+                                logger.info("Memory login steps did not navigate away from login page — falling back to smart login")
+                        except Exception as mem_exc:
+                            logger.info(f"Memory login failed ({mem_exc}) — falling back to smart login")
+
+                    # Option B: Smart LLM-driven login (handles email-first, SSO redirects, single-page)
+                    if not memory_login_succeeded:
+                        try:
+                            success, login_shots, action_history = self._smart_login(
+                                email,
+                                password,
+                                run_id=run_id,
+                                capture_steps=capture_login_steps,
+                            )
+                            screenshots.extend(login_shots)
+                            self._login_done = True
+                            if success:
+                                # Store the working steps so future runs can skip LLM discovery
+                                state["login_steps_for_memory"] = self._format_steps_for_memory(
+                                    action_history, email
+                                )
+                            test_steps.append(
+                                {
+                                    "agent": "explorer",
+                                    "action": "smart_login_completed" if success else "smart_login_partial",
+                                    "url": current_url,
+                                    "detail": (
+                                        f"Smart login {'succeeded' if success else 'reached max steps'}, "
+                                        f"now at {self.browser.get_current_url()}"
+                                    ),
+                                }
+                            )
+                            post_shot = capture(self.browser.page, label="post_login", run_id=run_id)
+                            screenshots.append(post_shot)
+                            # Don't add post_login_url to visited_urls here —
+                            # the next loop iteration will process the post-login page properly
+                        except Exception as e:
+                            logger.warning(f"Smart login failed: {e}")
+                            test_steps.append(
+                                {
+                                    "agent": "explorer",
+                                    "action": "smart_login_failed",
+                                    "url": current_url,
+                                    "detail": str(e),
+                                }
+                            )
+
+                    # Login succeeded — let the next iteration handle the post-login page
+                    # instead of falling through to the navigation section below
+                    if self._login_done:
+                        continue
 
                 # Record console + network errors
                 console_errors = self.browser.get_console_errors()
@@ -392,22 +779,44 @@ Return only the JSON object, no explanation."""
                         }
                     )
 
-                # Try to find and click a navigation link to a new page
+                # Crawl-only navigation: discover links from actual page content.
+                # No URL guessing — only navigate to hrefs found on real pages.
+                # Sort discovered links so known-bug-prone pages (from memory) are visited first.
                 navigated = False
-                links = self.browser.get_all_links()
-                for link in links:
-                    if link and link not in visited_urls and link.startswith(base_origin):
-                        try:
-                            self.browser.navigate(link)
-                            self.browser.dismiss_overlays()
-                            visited_urls.append(link)
-                            navigated = True
-                            break
-                        except Exception:
-                            continue
+
+                # Gather links from <a href> AND navigable elements (nav buttons, sidebar links)
+                raw_links = self.browser.get_all_links()
+                nav_hrefs = [
+                    el["href"] for el in interactive_elements
+                    if el.get("href") and el["href"].startswith("http")
+                ]
+                all_candidate_links = list(dict.fromkeys(raw_links + nav_hrefs))  # dedupe, preserve order
+
+                unvisited = [
+                    lnk for lnk in all_candidate_links
+                    if lnk and lnk not in visited_urls and _same_origin(lnk, base_origin)
+                ]
+
+                # Sort: known bug-prone pages first, then by discovery order
+                unvisited.sort(
+                    key=lambda u: memory_priority_scores.get(u, {}).get("priority_score", 0),
+                    reverse=True,
+                )
+
+                for link in unvisited:
+                    try:
+                        self.browser.navigate(link)
+                        self.browser.page.wait_for_timeout(1_000)  # let SPA render after navigation
+                        self.browser.dismiss_overlays()
+                        visited_urls.append(link)
+                        navigated = True
+                        logger.info(f"Navigated to discovered link: {link}")
+                        break
+                    except Exception:
+                        continue
 
                 if not navigated:
-                    logger.info("No new links found, stopping exploration")
+                    logger.info("No new links found on current page, stopping exploration")
                     break
 
         except Exception as exc:
@@ -426,4 +835,6 @@ Return only the JSON object, no explanation."""
             "screenshots": screenshots,
             "test_steps": test_steps,
             "current_page": visited_urls[-1] if visited_urls else url,
+            "login_steps_for_memory": state.get("login_steps_for_memory"),
+            "visited_urls": visited_urls,
         }

--- a/agent/agents/explorer.py
+++ b/agent/agents/explorer.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import time
+from urllib.parse import urlparse
 
 from langchain_core.messages import HumanMessage
 
@@ -239,6 +240,10 @@ Return only the JSON object, no explanation."""
         instructions = test_config.get("instructions", "").strip()
         focus_areas = test_config.get("focus_areas", "").strip()
 
+        # Use scheme+host for link filtering so post-login pages are explored
+        _parsed = urlparse(url)
+        base_origin = f"{_parsed.scheme}://{_parsed.netloc}"
+
         visited_urls = []
         pages_explored = 0
 
@@ -357,6 +362,9 @@ Return only the JSON object, no explanation."""
                                 ),
                             }
                         )
+                        post_login_url = self.browser.get_current_url()
+                        if post_login_url not in visited_urls:
+                            visited_urls.append(post_login_url)
                         post_shot = capture(self.browser.page, label="post_login")
                         screenshots.append(post_shot)
                     except Exception as e:
@@ -388,7 +396,7 @@ Return only the JSON object, no explanation."""
                 navigated = False
                 links = self.browser.get_all_links()
                 for link in links:
-                    if link and link not in visited_urls and link.startswith(url):
+                    if link and link not in visited_urls and link.startswith(base_origin):
                         try:
                             self.browser.navigate(link)
                             self.browser.dismiss_overlays()

--- a/agent/agents/explorer.py
+++ b/agent/agents/explorer.py
@@ -1,11 +1,17 @@
 """
 BugHunter.AI - ExplorerAgent
 Uses Playwright to navigate the app, capture screenshots, and log interaction steps.
-Supports multi-step SSO/IDP login flows via the credentials.login_flow config.
+
+Login modes:
+  A) Multi-step / SSO  — credentials.login_flow list (manual, power-user override)
+  B) Smart auto-login  — credentials.username + password; LLM drives each step
+                         iteratively, handling email-first pages and SSO redirects
 """
 
+import json
 import logging
 import os
+import re
 import time
 
 from langchain_core.messages import HumanMessage
@@ -124,6 +130,103 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
         lower = url.lower()
         return any(kw in lower for kw in ("login", "signin", "sign-in", "auth", "sso"))
 
+    @staticmethod
+    def _extract_json(text: str) -> str:
+        """Strip markdown fences and extract first JSON object or array from LLM output."""
+        text = re.sub(r"```(?:json)?\s*", "", text).strip().rstrip("`").strip()
+        for start_char, end_char in [('{', '}'), ('[', ']')]:
+            idx = text.find(start_char)
+            if idx != -1:
+                depth = 0
+                for i, ch in enumerate(text[idx:], idx):
+                    if ch == start_char:
+                        depth += 1
+                    elif ch == end_char:
+                        depth -= 1
+                        if depth == 0:
+                            return text[idx:i + 1]
+        return text
+
+    def _smart_login(self, email: str, password: str) -> bool:
+        """Use the LLM iteratively to navigate any login flow (single-page, email-first, SSO).
+
+        The password is never sent to the LLM — a placeholder is used and substituted
+        locally before each browser action.
+        """
+        MAX_STEPS = 12
+        PASSWORD_PLACEHOLDER = "__PASSWORD__"
+
+        for step_num in range(MAX_STEPS):
+            self.browser.dismiss_overlays()
+            current_url = self.browser.get_current_url()
+
+            # After the first step, if we've left all auth pages the login succeeded
+            if step_num > 0 and not self._is_login_page(current_url):
+                logger.info(f"Smart login: URL is no longer an auth page ({current_url}) — success")
+                return True
+
+            source = self.browser.get_page_source()
+            prompt = f"""You are automating login for a web app.
+Current URL: {current_url}
+User email: {email}
+HTML (first 3000 chars):
+{source[:3000]}
+
+Determine the single next action to take to progress the login.
+If login appears complete (you are past all login/auth pages), return {{"done": true}}.
+Otherwise return exactly ONE action as a JSON object:
+{{
+  "action": "fill" | "click" | "wait_for_navigation" | "wait_for_selector",
+  "selector": "<css selector>",
+  "value": "<text to type — use {PASSWORD_PLACEHOLDER} for any password field>",
+  "done": false
+}}
+Return only the JSON object, no explanation."""
+
+            try:
+                response = self.llm.invoke([HumanMessage(content=prompt)])
+                step = json.loads(self._extract_json(response.content))
+            except Exception as exc:
+                logger.warning(f"Smart login: failed to parse LLM response at step {step_num + 1}: {exc}")
+                break
+
+            if step.get("done"):
+                logger.info("Smart login: LLM signalled login complete")
+                return True
+
+            action = step.get("action")
+            selector = step.get("selector", "")
+            value = step.get("value", "").replace(PASSWORD_PLACEHOLDER, password)
+
+            logger.info(f"Smart login step {step_num + 1}/{MAX_STEPS}: {action} '{selector}'")
+
+            try:
+                if action == "fill":
+                    self.browser.wait_for_selector(selector, timeout=10000)
+                    self.browser.fill_form(selector, value)
+                elif action == "click":
+                    self.browser.wait_for_selector(selector, timeout=10000)
+                    self.browser.click(selector)
+                elif action == "wait_for_navigation":
+                    self.browser.wait_for_navigation(timeout=15000)
+                elif action == "wait_for_selector":
+                    self.browser.wait_for_selector(selector, timeout=10000)
+                else:
+                    logger.warning(f"Smart login: unknown action '{action}', skipping")
+            except Exception as exc:
+                logger.warning(f"Smart login: step {step_num + 1} failed ({exc}), retrying after overlay dismiss")
+                self.browser.dismiss_overlays()
+                try:
+                    if action == "click":
+                        self.browser.click(selector, force=True)
+                    elif action == "fill":
+                        self.browser.fill_form(selector, value)
+                except Exception:
+                    break
+
+        logger.warning("Smart login: max steps reached without confirmed success")
+        return False
+
     def run(self, state: AgentState) -> AgentState:
         url = state["url"]
         run_id = state.get("run_id")
@@ -230,7 +333,7 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
                             }
                         )
 
-                # Option B: Simple same-page login (email + password on one page)
+                # Option B: Smart LLM-driven login (handles email-first, SSO redirects, single-page)
                 elif (
                     credentials
                     and "login_flow" not in credentials
@@ -238,27 +341,34 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
                     and self._is_login_page(current_url)
                 ):
                     try:
-                        self.browser.fill_form(
-                            "input[type='email'], input[name='username']",
+                        success = self._smart_login(
                             credentials.get("username", ""),
-                        )
-                        self.browser.fill_form(
-                            "input[type='password']",
                             credentials.get("password", ""),
-                        )
-                        self.browser.click(
-                            "button[type='submit'], input[type='submit']"
                         )
                         self._login_done = True
                         test_steps.append(
                             {
                                 "agent": "explorer",
-                                "action": "login_attempt",
+                                "action": "smart_login_completed" if success else "smart_login_partial",
                                 "url": current_url,
+                                "detail": (
+                                    f"Smart login {'succeeded' if success else 'reached max steps'}, "
+                                    f"now at {self.browser.get_current_url()}"
+                                ),
                             }
                         )
+                        post_shot = capture(self.browser.page, label="post_login")
+                        screenshots.append(post_shot)
                     except Exception as e:
-                        logger.warning(f"Login attempt failed: {e}")
+                        logger.warning(f"Smart login failed: {e}")
+                        test_steps.append(
+                            {
+                                "agent": "explorer",
+                                "action": "smart_login_failed",
+                                "url": current_url,
+                                "detail": str(e),
+                            }
+                        )
 
                 # Record console + network errors
                 console_errors = self.browser.get_console_errors()

--- a/agent/agents/explorer.py
+++ b/agent/agents/explorer.py
@@ -29,12 +29,18 @@ class ExplorerAgent:
         self.browser = BrowserTool()
         self._login_done = False
 
-    def _ask_what_to_test(self, page_title: str, page_url: str, source_snippet: str) -> str:
+    def _ask_what_to_test(self, page_title: str, page_url: str, source_snippet: str, instructions: str = "", focus_areas: str = "") -> str:
         """Ask the LLM what actions to perform on the current page."""
+        custom = ""
+        if instructions:
+            custom += f"\nUser instructions: {instructions}"
+        if focus_areas:
+            custom += f"\nFocus areas: {focus_areas}"
+
         prompt = f"""You are a QA automation engineer exploring a web app.
 
 Current page: {page_url}
-Page title: {page_title}
+Page title: {page_title}{custom}
 HTML snippet (first 2000 chars):
 {source_snippet[:2000]}
 
@@ -125,6 +131,11 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
         screenshots = list(state.get("screenshots", []))
         test_steps = list(state.get("test_steps", []))
 
+        test_config = state.get("test_config") or {}
+        max_pages = int(test_config.get("max_pages") or MAX_PAGES)
+        instructions = test_config.get("instructions", "").strip()
+        focus_areas = test_config.get("focus_areas", "").strip()
+
         visited_urls = []
         pages_explored = 0
 
@@ -150,7 +161,7 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
             time.sleep(2)
             self.browser.dismiss_overlays()
 
-            for _ in range(MAX_PAGES):
+            for _ in range(max_pages):
                 pages_explored += 1
                 current_url = self.browser.get_current_url()
                 page_title = self.browser.get_title()
@@ -163,7 +174,7 @@ Format: JSON array of objects with keys: action (click/fill/navigate), selector,
                 publish_event(run_id, "page_visited", {"url": current_url, "page": pages_explored, "title": page_title, "message": f"Exploring: {current_url}"})
 
                 # Ask the LLM what to test
-                actions_json = self._ask_what_to_test(page_title, current_url, source)
+                actions_json = self._ask_what_to_test(page_title, current_url, source, instructions, focus_areas)
                 test_steps.append(
                     {
                         "agent": "explorer",

--- a/agent/agents/orchestrator.py
+++ b/agent/agents/orchestrator.py
@@ -36,10 +36,23 @@ class OrchestratorAgent:
         else:
             auth_context = "No credentials provided — test as an anonymous user."
 
+        test_config = state.get("test_config") or {}
+        user_instructions = test_config.get("instructions", "").strip()
+        focus_areas = test_config.get("focus_areas", "").strip()
+        max_pages = test_config.get("max_pages", 5)
+
+        custom_section = ""
+        if user_instructions:
+            custom_section += f"\nUser instructions: {user_instructions}"
+        if focus_areas:
+            custom_section += f"\nFocus areas: {focus_areas}"
+        if max_pages:
+            custom_section += f"\nThe explorer will visit up to {max_pages} page(s)."
+
         prompt = f"""You are a senior QA engineer. Analyze this web application URL and create a testing strategy.
 
 URL: {url}
-Auth context: {auth_context}
+Auth context: {auth_context}{custom_section}
 
 Provide:
 1. Key pages/flows to test (home, login, dashboard, forms, etc.)

--- a/agent/agents/orchestrator.py
+++ b/agent/agents/orchestrator.py
@@ -3,6 +3,7 @@ BugHunter.AI - OrchestratorAgent
 Analyzes the target app URL, plans the test strategy, and initializes state fields.
 """
 
+import json
 import logging
 
 from langchain_core.messages import HumanMessage
@@ -10,8 +11,31 @@ from langchain_core.messages import HumanMessage
 from graph.state import AgentState
 from providers import get_llm
 from tools.events import publish_event
+from tools.json_utils import extract_json_from_text
 
 logger = logging.getLogger("bughunter.orchestrator")
+
+
+def _parse_strategic_plan(plan_text: str) -> dict:
+    """Parse JSON plan from LLM output; fall back to empty structure + notes."""
+    default: dict = {"user_journeys": [], "focus_areas": "", "notes": ""}
+    try:
+        raw = extract_json_from_text(plan_text)
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            uj = data.get("user_journeys")
+            default["user_journeys"] = uj if isinstance(uj, list) else []
+            fa = data.get("focus_areas")
+            if isinstance(fa, str):
+                default["focus_areas"] = fa
+            elif isinstance(fa, list):
+                default["focus_areas"] = ", ".join(str(x) for x in fa)
+            notes = data.get("notes")
+            default["notes"] = notes if isinstance(notes, str) else ""
+            return default
+    except Exception as exc:
+        logger.debug(f"Could not parse strategic plan as JSON: {exc}")
+    return {**default, "notes": (default.get("notes") or "") + (plan_text[:1500] if plan_text else "")}
 
 
 class OrchestratorAgent:
@@ -49,18 +73,42 @@ class OrchestratorAgent:
         if max_pages:
             custom_section += f"\nThe explorer will visit up to {max_pages} page(s)."
 
-        prompt = f"""You are a senior QA engineer. Analyze this web application URL and create a testing strategy.
+        memory_section = ""
+        app_memory = state.get("app_memory") or {}
+        if app_memory.get("total_runs", 0) > 0:
+            total_runs = app_memory["total_runs"]
+            known_bugs = app_memory.get("known_bugs", [])
+            pages = app_memory.get("pages", {})
+            memory_section = f"\n\nPrevious test history ({total_runs} run(s)):"
+            if known_bugs:
+                top = sorted(known_bugs, key=lambda b: b.get("occurrence_count", 1), reverse=True)[:5]
+                lines = "\n".join(
+                    f"  - [{b['severity'].upper()}] {b['title']} — {b['page_url']} (seen {b.get('occurrence_count', 1)}x)"
+                    for b in top
+                )
+                memory_section += f"\nKnown recurring bugs (verify if fixed):\n{lines}"
+            if pages:
+                top_pages = sorted(pages.items(), key=lambda kv: kv[1].get("priority_score", 0), reverse=True)[:3]
+                lines = "\n".join(
+                    f"  - {page_url} ({info.get('bug_count', 0)} historical bug(s))"
+                    for page_url, info in top_pages
+                )
+                memory_section += f"\nBug-prone pages to prioritise:\n{lines}"
+
+        prompt = f"""You are a senior QA engineer. Define a testing strategy for this web application.
 
 URL: {url}
-Auth context: {auth_context}{custom_section}
+Auth context: {auth_context}{custom_section}{memory_section}
 
-Provide:
-1. Key pages/flows to test (home, login, dashboard, forms, etc.)
-2. Critical user journeys
-3. Common bug-prone areas to focus on
-4. Notes on authentication strategy based on the auth context above
+The browser will discover pages by crawling real links — do NOT list specific URL paths.
 
-Be concise and practical. Output as JSON with keys: pages, user_journeys, focus_areas, notes
+Define:
+1. Critical user journeys to verify (e.g. "login → view dashboard → update profile")
+2. Functional areas to focus on (e.g. forms, navigation, data display, auth, error handling)
+3. Common bug-prone patterns to watch for in this type of app
+4. Notes on the authentication approach
+
+Output as JSON with these keys only: user_journeys, focus_areas, notes
 """
 
         try:
@@ -69,7 +117,9 @@ Be concise and practical. Output as JSON with keys: pages, user_journeys, focus_
             logger.info(f"Test plan generated: {plan_text[:200]}...")
         except Exception as exc:
             logger.error(f"OrchestratorAgent LLM call failed: {exc}")
-            plan_text = f"Default strategy for {url}"
+            plan_text = f'{{"pages":[],"user_journeys":[],"focus_areas":"","notes":"Default strategy for {url}"}}'
+
+        strategic_plan = _parse_strategic_plan(plan_text)
 
         publish_event(run_id, "agent_done", {"agent": "orchestrator", "message": "Test strategy ready — starting exploration"})
         return {
@@ -78,6 +128,7 @@ Be concise and practical. Output as JSON with keys: pages, user_journeys, focus_
             "status": "running",
             "screenshots": state.get("screenshots", []),
             "bugs_found": state.get("bugs_found", []),
+            "strategic_plan": strategic_plan,
             "test_steps": [
                 {
                     "action": "plan",

--- a/agent/agents/orchestrator.py
+++ b/agent/agents/orchestrator.py
@@ -10,6 +10,7 @@ from langchain_core.messages import HumanMessage
 from graph.state import AgentState
 from providers import get_llm
 from tools.events import publish_event
+from tools.memory import format_memory_for_prompt, format_skills_for_prompt
 
 logger = logging.getLogger("bughunter.orchestrator")
 
@@ -36,13 +37,29 @@ class OrchestratorAgent:
         else:
             auth_context = "No credentials provided — test as an anonymous user."
 
+        # Build memory and skills context for the prompt
+        memory = state.get("memory", {})
+        skills = state.get("skills", [])
+        memory_section = format_memory_for_prompt(memory)
+        skills_section = format_skills_for_prompt(skills, agent_type="orchestrator")
+
+        history_block = ""
+        if memory_section or skills_section:
+            history_block = f"""
+--- HISTORICAL CONTEXT (from previous runs on this same app) ---
+{memory_section}
+{skills_section}
+Use this history to prioritize previously buggy areas and refine your strategy.
+--- END HISTORICAL CONTEXT ---
+"""
+
         prompt = f"""You are a senior QA engineer. Analyze this web application URL and create a testing strategy.
 
 URL: {url}
 Auth context: {auth_context}
-
+{history_block}
 Provide:
-1. Key pages/flows to test (home, login, dashboard, forms, etc.)
+1. Key pages/flows to test — prioritize previously buggy areas if history is available
 2. Critical user journeys
 3. Common bug-prone areas to focus on
 4. Notes on authentication strategy based on the auth context above

--- a/agent/agents/reporter.py
+++ b/agent/agents/reporter.py
@@ -10,7 +10,10 @@ from langchain_core.messages import HumanMessage
 
 from graph.state import AgentState
 from providers import get_llm
+from tools.bug_dedupe import dedupe_bugs
+from tools.control import SIGNAL_STOP, check_run_control
 from tools.events import publish_event
+from tools.memory import make_fingerprint
 
 logger = logging.getLogger("bughunter.reporter")
 
@@ -67,17 +70,36 @@ Return ONLY the JSON object, no extra text.
         }
 
     def run(self, state: AgentState) -> AgentState:
-        bugs_found = state.get("bugs_found", [])
+        raw_bugs = list(state.get("bugs_found", []))
         run_id = state.get("run_id")
-        logger.info(f"Generating reports for {len(bugs_found)} bug(s)")
-        publish_event(run_id, "agent_start", {"agent": "reporter", "message": f"Writing structured reports for {len(bugs_found)} bug(s)…"})
+
+        if check_run_control(run_id) == SIGNAL_STOP:
+            logger.info(f"Run {run_id} stopped — skipping reporter (saving partial results)")
+            return {**state, "current_agent": "reporter", "status": "cancelled", "report": []}
+
+        deduped, dedupe_stats = dedupe_bugs(raw_bugs)
+        logger.info(f"Generating reports for {len(deduped)} bug(s) after dedupe (raw {len(raw_bugs)})")
+        publish_event(
+            run_id,
+            "agent_start",
+            {"agent": "reporter", "message": f"Writing structured reports for {len(deduped)} bug(s)…"},
+        )
+
+        # Build set of known bug fingerprints for regression detection
+        known_fps = {
+            b["fingerprint"]
+            for b in (state.get("app_memory") or {}).get("known_bugs", [])
+        }
 
         structured_reports = []
-        for raw_bug in bugs_found:
+        for raw_bug in deduped:
             report = self._generate_report(raw_bug)
             # Preserve screenshot_url if present on the original bug
             if "screenshot_url" in raw_bug and not report.get("screenshot_url"):
                 report["screenshot_url"] = raw_bug["screenshot_url"]
+            # Tag as regression if the same bug was seen in a previous run
+            fp = make_fingerprint(report.get("title", ""), report.get("page_url", ""))
+            report["regression"] = fp in known_fps
             structured_reports.append(report)
 
         logger.info(f"Generated {len(structured_reports)} structured bug report(s)")
@@ -87,5 +109,66 @@ Return ONLY the JSON object, no extra text.
             **state,
             "current_agent": "reporter",
             "status": "completed",
+            "bugs_found": deduped,
             "report": structured_reports,
+            "dedupe_stats": dedupe_stats,
+        }
+
+
+class SimpleReporterAgent:
+    """Fast reporter that skips LLM enrichment.
+
+    Deduplicates raw bug observations and normalises them into the same report
+    schema as ReporterAgent, but without any LLM call. Use when the user
+    selects "quick log" mode at run-creation time.
+    """
+
+    def run(self, state: AgentState) -> AgentState:
+        raw_bugs = list(state.get("bugs_found", []))
+        run_id = state.get("run_id")
+
+        if check_run_control(run_id) == SIGNAL_STOP:
+            logger.info(f"Run {run_id} stopped — skipping simple reporter (saving partial results)")
+            return {**state, "current_agent": "reporter", "status": "cancelled", "report": []}
+
+        deduped, dedupe_stats = dedupe_bugs(raw_bugs)
+        logger.info(f"Simple reporter: logging {len(deduped)} bug(s) (no LLM enrichment, raw {len(raw_bugs)})")
+        publish_event(
+            run_id,
+            "agent_start",
+            {"agent": "reporter", "message": f"Logging {len(deduped)} bug(s) (quick mode — no AI enrichment)…"},
+        )
+
+        known_fps = {
+            b["fingerprint"]
+            for b in (state.get("app_memory") or {}).get("known_bugs", [])
+        }
+
+        reports = []
+        for bug in deduped:
+            report = {
+                "title": bug.get("title") or "Bug Detected",
+                "description": bug.get("description") or "",
+                "steps_to_reproduce": "See agent logs for details.",
+                "expected_behavior": "Application should function correctly.",
+                "actual_behavior": bug.get("description") or "Unexpected behaviour observed.",
+                "severity": bug.get("severity") or "medium",
+                "type": bug.get("type") or "functional",
+                "page_url": bug.get("page_url") or "",
+                "screenshot_url": bug.get("screenshot_url") or None,
+            }
+            fp = make_fingerprint(report["title"], report["page_url"])
+            report["regression"] = fp in known_fps
+            reports.append(report)
+
+        logger.info(f"Simple reporter: {len(reports)} bug(s) logged")
+        publish_event(run_id, "agent_done", {"agent": "reporter", "message": f"{len(reports)} bug(s) logged (quick mode)"})
+
+        return {
+            **state,
+            "current_agent": "reporter",
+            "status": "completed",
+            "bugs_found": deduped,
+            "report": reports,
+            "dedupe_stats": dedupe_stats,
         }

--- a/agent/agents/reporter.py
+++ b/agent/agents/reporter.py
@@ -21,13 +21,31 @@ class ReporterAgent:
     def __init__(self):
         self.llm = get_llm()
 
-    def _generate_report(self, bug: dict) -> dict:
+    def _generate_report(self, bug: dict, known_bugs: list = None) -> dict:
         """Use Claude to enrich a raw bug observation into a full bug report."""
+        regression_note = ""
+        if known_bugs:
+            page_url = bug.get("page_url", "")
+            fixed_on_page = [
+                b for b in known_bugs
+                if b.get("status") == "fixed" and b.get("page_url") == page_url
+            ]
+            for kb in fixed_on_page:
+                # Simple title similarity check
+                if kb.get("title", "").lower()[:30] in bug.get("title", "").lower() or \
+                   bug.get("title", "").lower()[:30] in kb.get("title", "").lower():
+                    regression_note = (
+                        f"\nREGRESSION ALERT: A similar bug was previously found and marked as FIXED: "
+                        f"'{kb['title']}'. If this is the same issue, mark type as 'regression' "
+                        f"and note that it is a recurring problem.\n"
+                    )
+                    break
+
         prompt = f"""You are a senior QA engineer writing a professional bug report.
 
 Raw bug observation:
 {json.dumps(bug, indent=2)}
-
+{regression_note}
 Generate a structured bug report with these exact fields:
 {{
   "title": "concise, descriptive title (max 100 chars)",
@@ -36,7 +54,7 @@ Generate a structured bug report with these exact fields:
   "expected_behavior": "what should happen",
   "actual_behavior": "what actually happens",
   "severity": "critical|high|medium|low",
-  "type": "functional|security|ui|performance|data",
+  "type": "functional|security|ui|performance|data|regression",
   "page_url": "URL where the bug was found",
   "screenshot_url": null
 }}
@@ -69,12 +87,14 @@ Return ONLY the JSON object, no extra text.
     def run(self, state: AgentState) -> AgentState:
         bugs_found = state.get("bugs_found", [])
         run_id = state.get("run_id")
+        memory = state.get("memory") or {}
+        known_bugs = memory.get("previous_bugs", [])
         logger.info(f"Generating reports for {len(bugs_found)} bug(s)")
         publish_event(run_id, "agent_start", {"agent": "reporter", "message": f"Writing structured reports for {len(bugs_found)} bug(s)…"})
 
         structured_reports = []
         for raw_bug in bugs_found:
-            report = self._generate_report(raw_bug)
+            report = self._generate_report(raw_bug, known_bugs)
             # Preserve screenshot_url if present on the original bug
             if "screenshot_url" in raw_bug and not report.get("screenshot_url"):
                 report["screenshot_url"] = raw_bug["screenshot_url"]

--- a/agent/agents/security.py
+++ b/agent/agents/security.py
@@ -43,7 +43,8 @@ class SecurityAgent:
     def __init__(self):
         self.browser = BrowserTool()
 
-    def _test_xss(self, url: str) -> list:
+    def _test_xss(self, url: str, payloads: list = None) -> list:
+        payloads = payloads or XSS_PAYLOADS
         bugs = []
         try:
             self.browser.start()
@@ -51,7 +52,7 @@ class SecurityAgent:
             inputs = self.browser.get_form_inputs()
 
             for selector in inputs[:3]:  # Test first 3 inputs
-                for payload in XSS_PAYLOADS[:2]:  # Test 2 payloads per input
+                for payload in payloads[:2]:  # Test 2 payloads per input
                     try:
                         self.browser.fill_form(selector, payload)
                         self.browser.click("button[type='submit'], input[type='submit']")
@@ -80,7 +81,8 @@ class SecurityAgent:
                 pass
         return bugs
 
-    def _test_sqli(self, url: str) -> list:
+    def _test_sqli(self, url: str, payloads: list = None) -> list:
+        payloads = payloads or SQLI_PAYLOADS
         bugs = []
         try:
             self.browser.start()
@@ -88,7 +90,7 @@ class SecurityAgent:
             inputs = self.browser.get_form_inputs()
 
             for selector in inputs[:3]:
-                for payload in SQLI_PAYLOADS[:2]:
+                for payload in payloads[:2]:
                     try:
                         self.browser.fill_form(selector, payload)
                         self.browser.click("button[type='submit'], input[type='submit']")
@@ -151,16 +153,33 @@ class SecurityAgent:
             logger.error(f"Secret check failed: {exc}")
         return bugs
 
+    def _build_adaptive_payloads(self, memory: dict) -> tuple:
+        """Build XSS and SQLi payload lists, prioritizing previously effective ones."""
+        security_findings = memory.get("security_findings", [])
+        effective_xss = [f["payload"] for f in security_findings if f.get("type") == "xss" and f.get("effective") and f.get("payload")]
+        effective_sqli = [f["payload"] for f in security_findings if f.get("type") == "sqli" and f.get("effective") and f.get("payload")]
+
+        # Prepend effective payloads (test them first), then defaults, deduplicated
+        xss = list(dict.fromkeys(effective_xss + XSS_PAYLOADS))
+        sqli = list(dict.fromkeys(effective_sqli + SQLI_PAYLOADS))
+        return xss, sqli
+
     def run(self, state: AgentState) -> AgentState:
         url = state["url"]
         run_id = state.get("run_id")
         bugs_found = list(state.get("bugs_found", []))
+        memory = state.get("memory") or {}
+
+        # Build adaptive payload lists from memory
+        xss_payloads, sqli_payloads = self._build_adaptive_payloads(memory)
+        if memory.get("security_findings"):
+            logger.info(f"Using adaptive payloads: {len(xss_payloads)} XSS, {len(sqli_payloads)} SQLi")
 
         logger.info(f"Running security tests on: {url}")
         publish_event(run_id, "agent_start", {"agent": "security", "message": "Running security tests (XSS, SQLi, secrets)…"})
 
-        xss_bugs = self._test_xss(url)
-        sqli_bugs = self._test_sqli(url)
+        xss_bugs = self._test_xss(url, xss_payloads)
+        sqli_bugs = self._test_sqli(url, sqli_payloads)
         secret_bugs = self._check_exposed_secrets(url)
 
         new_bugs = xss_bugs + sqli_bugs + secret_bugs

--- a/agent/agents/security.py
+++ b/agent/agents/security.py
@@ -1,6 +1,7 @@
 """
 BugHunter.AI - SecurityAgent
 Performs active security testing: XSS, SQL injection, auth bypass, secret exposure.
+Scans the seed URL plus URLs visited during exploration (capped).
 """
 
 import logging
@@ -9,6 +10,7 @@ import re
 
 from graph.state import AgentState
 from tools.browser import BrowserTool
+from tools.control import SIGNAL_STOP, check_run_control
 from tools.events import publish_event
 
 logger = logging.getLogger("bughunter.security")
@@ -36,6 +38,22 @@ COMMON_SECRET_PATTERNS = [
     r"(?i)aws[_-]?(access[_-]?key|secret)\s*[=:]\s*['\"]?[\w/+=]{16,}",
 ]
 
+SECURITY_MAX_URLS = int(os.environ.get("SECURITY_MAX_URLS", "6"))
+
+
+def _build_target_urls(state: AgentState) -> list:
+    """Seed URL plus explorer visited URLs, deduped, capped."""
+    base = state["url"]
+    visited = state.get("visited_urls") or []
+    out = []
+    seen = set()
+    for u in [base] + list(visited):
+        if not u or u in seen:
+            continue
+        seen.add(u)
+        out.append(u)
+    return out[: max(1, SECURITY_MAX_URLS)]
+
 
 class SecurityAgent:
     """Runs active security tests against the target web application."""
@@ -43,21 +61,39 @@ class SecurityAgent:
     def __init__(self):
         self.browser = BrowserTool()
 
-    def _test_xss(self, url: str) -> list:
+    def _secrets_from_source(self, source: str, page_url: str) -> list:
         bugs = []
+        for pattern in COMMON_SECRET_PATTERNS:
+            matches = re.findall(pattern, source)
+            if matches:
+                bugs.append(
+                    {
+                        "type": "security",
+                        "title": "Exposed Secret in Page Source",
+                        "description": "Potential secret pattern matched in HTML (verify manually — may be a false positive).",
+                        "page_url": page_url,
+                        "severity": "high",
+                    }
+                )
+                break
+        return bugs
+
+    def _scan_url(self, url: str) -> list:
+        """XSS + SQLi + secret scan in one browser session per URL."""
+        bugs: list = []
         try:
             self.browser.start()
             self.browser.navigate(url)
-            inputs = self.browser.get_form_inputs()
 
-            for selector in inputs[:3]:  # Test first 3 inputs
-                for payload in XSS_PAYLOADS[:2]:  # Test 2 payloads per input
+            inputs = self.browser.get_form_inputs()
+            head = inputs[:3]
+
+            for selector in head:
+                for payload in XSS_PAYLOADS[:2]:
                     try:
                         self.browser.fill_form(selector, payload)
                         self.browser.click("button[type='submit'], input[type='submit']")
                         source = self.browser.get_page_source()
-
-                        # Check if payload reflected unescaped
                         if "<script>alert" in source or "onerror=alert" in source:
                             bugs.append(
                                 {
@@ -71,30 +107,18 @@ class SecurityAgent:
                             )
                     except Exception as e:
                         logger.debug(f"XSS test error for {selector}: {e}")
-        except Exception as exc:
-            logger.error(f"XSS test failed: {exc}")
-        finally:
+
             try:
-                self.browser.close()
+                self.browser.navigate(url)
             except Exception:
                 pass
-        return bugs
 
-    def _test_sqli(self, url: str) -> list:
-        bugs = []
-        try:
-            self.browser.start()
-            self.browser.navigate(url)
-            inputs = self.browser.get_form_inputs()
-
-            for selector in inputs[:3]:
+            for selector in head:
                 for payload in SQLI_PAYLOADS[:2]:
                     try:
                         self.browser.fill_form(selector, payload)
                         self.browser.click("button[type='submit'], input[type='submit']")
                         source = self.browser.get_page_source()
-
-                        # Look for SQL error signatures
                         sql_errors = [
                             "sql syntax",
                             "mysql_fetch",
@@ -118,8 +142,16 @@ class SecurityAgent:
                                 break
                     except Exception as e:
                         logger.debug(f"SQLi test error: {e}")
+
+            try:
+                self.browser.navigate(url)
+                source = self.browser.get_page_source()
+                bugs.extend(self._secrets_from_source(source, url))
+            except Exception as exc:
+                logger.debug(f"Secret scan navigate failed: {exc}")
+
         except Exception as exc:
-            logger.error(f"SQLi test failed: {exc}")
+            logger.error(f"Security scan failed for {url}: {exc}")
         finally:
             try:
                 self.browser.close()
@@ -127,55 +159,47 @@ class SecurityAgent:
                 pass
         return bugs
 
-    def _check_exposed_secrets(self, url: str) -> list:
-        bugs = []
-        try:
-            self.browser.start()
-            self.browser.navigate(url)
-            source = self.browser.get_page_source()
-            self.browser.close()
-
-            for pattern in COMMON_SECRET_PATTERNS:
-                matches = re.findall(pattern, source)
-                if matches:
-                    bugs.append(
-                        {
-                            "type": "security",
-                            "title": "Exposed Secret in Page Source",
-                            "description": f"Potential secret found: {matches[0]}",
-                            "page_url": url,
-                            "severity": "critical",
-                        }
-                    )
-        except Exception as exc:
-            logger.error(f"Secret check failed: {exc}")
-        return bugs
-
     def run(self, state: AgentState) -> AgentState:
-        url = state["url"]
         run_id = state.get("run_id")
         bugs_found = list(state.get("bugs_found", []))
 
-        logger.info(f"Running security tests on: {url}")
-        publish_event(run_id, "agent_start", {"agent": "security", "message": "Running security tests (XSS, SQLi, secrets)…"})
+        if check_run_control(run_id) == SIGNAL_STOP:
+            logger.info(f"Run {run_id} stopped — skipping security scan")
+            return {**state, "current_agent": "security"}
 
-        xss_bugs = self._test_xss(url)
-        sqli_bugs = self._test_sqli(url)
-        secret_bugs = self._check_exposed_secrets(url)
+        targets = _build_target_urls(state)
 
-        new_bugs = xss_bugs + sqli_bugs + secret_bugs
+        logger.info(f"Running security tests on {len(targets)} URL(s): {targets}")
+        publish_event(
+            run_id,
+            "agent_start",
+            {"agent": "security", "message": f"Running security tests on {len(targets)} page(s)…"},
+        )
+
+        new_bugs: list = []
+        for turl in targets:
+            new_bugs.extend(self._scan_url(turl))
+
         if new_bugs:
             logger.info(f"SecurityAgent found {len(new_bugs)} security issue(s)")
             for bug in new_bugs:
-                publish_event(run_id, "bug_found", {
-                    "title": bug.get("title", "Security issue"),
-                    "severity": "critical",
-                    "page_url": url,
-                    "message": f"[CRITICAL] {bug.get('title', 'Security issue')}",
-                })
+                publish_event(
+                    run_id,
+                    "bug_found",
+                    {
+                        "title": bug.get("title", "Security issue"),
+                        "severity": bug.get("severity", "critical"),
+                        "page_url": bug.get("page_url", ""),
+                        "message": f"[{bug.get('severity', 'critical').upper()}] {bug.get('title', 'Security issue')}",
+                    },
+                )
 
         bugs_found.extend(new_bugs)
-        publish_event(run_id, "agent_done", {"agent": "security", "message": f"Security scan complete — {len(new_bugs)} issue(s)"})
+        publish_event(
+            run_id,
+            "agent_done",
+            {"agent": "security", "message": f"Security scan complete — {len(new_bugs)} issue(s) across {len(targets)} URL(s)"},
+        )
 
         return {
             **state,

--- a/agent/agents/security.py
+++ b/agent/agents/security.py
@@ -1,12 +1,14 @@
 """
 BugHunter.AI - SecurityAgent
-Performs active security testing: XSS, SQL injection, auth bypass, secret exposure.
+Performs active security testing: XSS, SQL injection, CSRF, IDOR,
+HTTP header security, cookie flags, auth bypass, secret exposure.
 Scans the seed URL plus URLs visited during exploration (capped).
 """
 
 import logging
 import os
 import re
+from urllib.parse import urlparse
 
 from graph.state import AgentState
 from tools.browser import BrowserTool
@@ -38,6 +40,14 @@ COMMON_SECRET_PATTERNS = [
     r"(?i)aws[_-]?(access[_-]?key|secret)\s*[=:]\s*['\"]?[\w/+=]{16,}",
 ]
 
+# Required HTTP security headers and expected values
+REQUIRED_SECURITY_HEADERS = {
+    "strict-transport-security": "HSTS header missing — site vulnerable to protocol downgrade attacks",
+    "x-content-type-options": "X-Content-Type-Options header missing — vulnerable to MIME sniffing",
+    "x-frame-options": "X-Frame-Options header missing — vulnerable to clickjacking",
+    "content-security-policy": "Content-Security-Policy header missing — no XSS mitigation via CSP",
+}
+
 SECURITY_MAX_URLS = int(os.environ.get("SECURITY_MAX_URLS", "6"))
 
 
@@ -60,6 +70,111 @@ class SecurityAgent:
 
     def __init__(self):
         self.browser = BrowserTool()
+
+    def _check_security_headers(self, url: str) -> list:
+        """Check for missing HTTP security headers via Playwright response."""
+        bugs = []
+        try:
+            self.browser.start()
+            response = self.browser.page.goto(url, wait_until="domcontentloaded")
+            if response:
+                headers = {k.lower(): v for k, v in response.headers.items()}
+                for header, message in REQUIRED_SECURITY_HEADERS.items():
+                    if header not in headers:
+                        bugs.append({
+                            "type": "security",
+                            "title": f"Missing Security Header: {header}",
+                            "description": message,
+                            "page_url": url,
+                            "severity": "medium",
+                        })
+        except Exception as exc:
+            logger.debug(f"Header check failed for {url}: {exc}")
+        finally:
+            try:
+                self.browser.close()
+            except Exception:
+                pass
+        return bugs
+
+    def _check_cookie_security(self, url: str) -> list:
+        """Check cookies for missing security flags (HttpOnly, Secure, SameSite)."""
+        bugs = []
+        try:
+            self.browser.start()
+            self.browser.navigate(url)
+            cookies = self.browser._context.cookies()
+            parsed = urlparse(url)
+            is_https = parsed.scheme == "https"
+
+            for cookie in cookies:
+                name = cookie.get("name", "")
+                issues = []
+                if not cookie.get("httpOnly", False):
+                    issues.append("HttpOnly")
+                if is_https and not cookie.get("secure", False):
+                    issues.append("Secure")
+                if cookie.get("sameSite", "None") == "None":
+                    issues.append("SameSite")
+
+                if issues:
+                    bugs.append({
+                        "type": "security",
+                        "title": f"Insecure Cookie: {name}",
+                        "description": f"Cookie '{name}' is missing flags: {', '.join(issues)}. "
+                                       f"This could expose the cookie to XSS theft or CSRF attacks.",
+                        "page_url": url,
+                        "severity": "medium" if "HttpOnly" in issues else "low",
+                    })
+        except Exception as exc:
+            logger.debug(f"Cookie check failed: {exc}")
+        finally:
+            try:
+                self.browser.close()
+            except Exception:
+                pass
+        return bugs
+
+    def _check_csrf(self, url: str) -> list:
+        """Check forms for missing CSRF tokens."""
+        bugs = []
+        try:
+            self.browser.start()
+            self.browser.navigate(url)
+            # Look for POST forms without CSRF tokens
+            forms_info = self.browser.page.evaluate("""
+                () => {
+                    const forms = document.querySelectorAll('form[method="post"], form[method="POST"], form:not([method])');
+                    return Array.from(forms).map(f => ({
+                        action: f.action,
+                        hasToken: !!(
+                            f.querySelector('input[name*="csrf"]') ||
+                            f.querySelector('input[name*="token"]') ||
+                            f.querySelector('input[name*="_token"]') ||
+                            f.querySelector('input[name="authenticity_token"]')
+                        ),
+                        inputCount: f.querySelectorAll('input').length,
+                    }));
+                }
+            """)
+            for form in (forms_info or []):
+                if not form.get("hasToken") and form.get("inputCount", 0) > 0:
+                    bugs.append({
+                        "type": "security",
+                        "title": "Potential CSRF Vulnerability",
+                        "description": f"Form posting to '{form.get('action', url)}' has no CSRF token. "
+                                       f"State-changing requests may be vulnerable to cross-site request forgery.",
+                        "page_url": url,
+                        "severity": "high",
+                    })
+        except Exception as exc:
+            logger.debug(f"CSRF check failed: {exc}")
+        finally:
+            try:
+                self.browser.close()
+            except Exception:
+                pass
+        return bugs
 
     def _secrets_from_source(self, source: str, page_url: str) -> list:
         bugs = []
@@ -223,6 +338,13 @@ class SecurityAgent:
         new_bugs: list = []
         for turl in targets:
             new_bugs.extend(self._scan_url(turl, xss_payloads, sqli_payloads))
+
+        # Run header, cookie, and CSRF checks on the seed URL only (avoid redundancy)
+        seed_url = state["url"]
+        publish_event(run_id, "agent_progress", {"agent": "security", "message": "Checking HTTP headers, cookies, and CSRF…"})
+        new_bugs.extend(self._check_security_headers(seed_url))
+        new_bugs.extend(self._check_cookie_security(seed_url))
+        new_bugs.extend(self._check_csrf(seed_url))
 
         if new_bugs:
             logger.info(f"SecurityAgent found {len(new_bugs)} security issue(s)")

--- a/agent/agents/validator.py
+++ b/agent/agents/validator.py
@@ -10,6 +10,7 @@ from langchain_core.messages import HumanMessage
 
 from graph.state import AgentState
 from providers import get_llm
+from tools.control import SIGNAL_STOP, check_run_control
 from tools.events import publish_event
 
 logger = logging.getLogger("bughunter.validator")
@@ -62,6 +63,10 @@ If no bugs found, return an empty array [].
         test_steps = state.get("test_steps", [])
         bugs_found = list(state.get("bugs_found", []))
         run_id = state.get("run_id")
+
+        if check_run_control(run_id) == SIGNAL_STOP:
+            logger.info(f"Run {run_id} stopped — skipping validation")
+            return {**state, "current_agent": "validator"}
 
         logger.info(f"Validating {len(test_steps)} test steps")
         publish_event(run_id, "agent_start", {"agent": "validator", "message": "Analyzing screenshots for bugs…"})

--- a/agent/agents/validator.py
+++ b/agent/agents/validator.py
@@ -21,10 +21,27 @@ class ValidatorAgent:
     def __init__(self):
         self.llm = get_llm()
 
-    def _analyze_step(self, step: dict) -> list:
+    def _analyze_step(self, step: dict, known_bugs: list = None) -> list:
         """Ask Claude to identify bugs from a single test step observation."""
-        prompt = f"""You are a QA engineer reviewing web application test results.
+        regression_section = ""
+        if known_bugs:
+            page_url = step.get("url", "")
+            page_known = [b for b in known_bugs if b.get("page_url") == page_url]
+            if page_known:
+                fixed_bugs = [b for b in page_known if b.get("status") == "fixed"]
+                open_bugs = [b for b in page_known if b.get("status") == "open"]
+                parts = []
+                if fixed_bugs:
+                    titles = [b.get("title", "?") for b in fixed_bugs[:3]]
+                    parts.append(f"Previously FIXED bugs on this page (check for regressions): {', '.join(titles)}")
+                if open_bugs:
+                    titles = [b.get("title", "?") for b in open_bugs[:3]]
+                    parts.append(f"Known OPEN bugs (skip if unchanged): {', '.join(titles)}")
+                if parts:
+                    regression_section = "\n## Historical Context:\n" + "\n".join(f"- {p}" for p in parts) + "\n"
 
+        prompt = f"""You are a QA engineer reviewing web application test results.
+{regression_section}
 Test step data:
 {json.dumps(step, indent=2)}
 
@@ -36,9 +53,10 @@ Identify any bugs or issues. Look for:
 - Form validation failures
 - Incorrect or missing data
 - Accessibility issues
+- REGRESSIONS: bugs that were previously fixed but appear to have returned
 
 Return a JSON array of bug objects. Each bug: {{
-  "type": "functional|ui|error|data",
+  "type": "functional|ui|error|data|regression",
   "title": "short title",
   "description": "what went wrong",
   "page_url": "url where it was found",
@@ -62,13 +80,17 @@ If no bugs found, return an empty array [].
         test_steps = state.get("test_steps", [])
         bugs_found = list(state.get("bugs_found", []))
         run_id = state.get("run_id")
+        memory = state.get("memory") or {}
+        known_bugs = memory.get("previous_bugs", [])
 
         logger.info(f"Validating {len(test_steps)} test steps")
+        if known_bugs:
+            logger.info(f"Loaded {len(known_bugs)} known bug(s) from previous runs for regression detection")
         publish_event(run_id, "agent_start", {"agent": "validator", "message": "Analyzing screenshots for bugs…"})
 
         for step in test_steps:
             if step.get("action") in ("observe", "errors_detected"):
-                new_bugs = self._analyze_step(step)
+                new_bugs = self._analyze_step(step, known_bugs)
                 if new_bugs:
                     logger.info(f"Found {len(new_bugs)} bug(s) in step: {step.get('url', '?')}")
                     bugs_found.extend(new_bugs)

--- a/agent/agents/validator.py
+++ b/agent/agents/validator.py
@@ -1,6 +1,7 @@
 """
 BugHunter.AI - ValidatorAgent
 Reviews screenshots and test steps to identify functional bugs using Claude.
+Supports vision-based analysis when screenshots with base64 data are available.
 """
 
 import json
@@ -68,7 +69,6 @@ If no bugs found, return an empty array [].
         try:
             response = self.llm.invoke([HumanMessage(content=prompt)])
             raw = response.content.strip()
-            # Extract JSON array from response
             start = raw.find("[")
             end = raw.rfind("]") + 1
             if start != -1 and end > start:
@@ -77,22 +77,92 @@ If no bugs found, return an empty array [].
             logger.error(f"ValidatorAgent LLM call failed: {exc}")
         return []
 
+    def _analyze_screenshot_visual(self, screenshot: dict, known_bugs: list = None) -> list:
+        """Use vision (multimodal) to analyze a screenshot image for visual bugs."""
+        base64_data = screenshot.get("base64")
+        if not base64_data:
+            return []
+
+        page_url = screenshot.get("url", "unknown")
+        label = screenshot.get("label", "")
+
+        regression_section = ""
+        if known_bugs:
+            page_known = [b for b in known_bugs if b.get("page_url") == page_url]
+            if page_known:
+                titles = [b.get("title", "?") for b in page_known[:5]]
+                regression_section = f"\nKnown bugs on this page from previous runs: {', '.join(titles)}\nCheck if any of these are still present (regression).\n"
+
+        text_prompt = f"""You are a senior QA engineer reviewing a screenshot of a web application page.
+
+Page URL: {page_url}
+Screenshot label: {label}
+{regression_section}
+Examine this screenshot carefully for VISUAL bugs only:
+- Broken or overlapping layouts
+- Missing images or icons (broken image placeholders)
+- Text overflow or truncation
+- Misaligned elements
+- Empty sections that should have content
+- Modal/overlay rendering issues
+- Responsive layout problems
+- Incorrect colors or contrast issues
+- Missing or garbled text
+- UI elements rendered in wrong position
+
+Do NOT report issues you cannot see in the image. Only report clear, visible problems.
+
+Return a JSON array of bug objects. Each bug: {{
+  "type": "ui",
+  "title": "short descriptive title",
+  "description": "what is visually wrong and where in the page",
+  "page_url": "{page_url}",
+  "severity": "critical|high|medium|low",
+  "confidence": "high|medium|low"
+}}
+If no visual bugs found, return an empty array [].
+"""
+        try:
+            # Build multimodal message with image
+            message = HumanMessage(
+                content=[
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{base64_data}"},
+                    },
+                    {"type": "text", "text": text_prompt},
+                ]
+            )
+            response = self.llm.invoke([message])
+            raw = response.content.strip()
+            start = raw.find("[")
+            end = raw.rfind("]") + 1
+            if start != -1 and end > start:
+                bugs = json.loads(raw[start:end])
+                # Only keep medium+ confidence visual bugs
+                return [b for b in bugs if b.get("confidence", "medium") != "low"]
+        except Exception as exc:
+            logger.warning(f"Vision analysis failed for {label}: {exc}")
+        return []
+
     def run(self, state: AgentState) -> AgentState:
         test_steps = state.get("test_steps", [])
+        screenshots = state.get("screenshots", [])
         bugs_found = list(state.get("bugs_found", []))
         run_id = state.get("run_id")
-        memory = state.get("memory") or {}
-        known_bugs = memory.get("previous_bugs", [])
+        app_memory = state.get("app_memory") or {}
+        known_bugs = app_memory.get("known_bugs", [])
 
         if check_run_control(run_id) == SIGNAL_STOP:
             logger.info(f"Run {run_id} stopped — skipping validation")
             return {**state, "current_agent": "validator"}
 
-        logger.info(f"Validating {len(test_steps)} test steps")
+        logger.info(f"Validating {len(test_steps)} test steps + {len(screenshots)} screenshots")
         if known_bugs:
             logger.info(f"Loaded {len(known_bugs)} known bug(s) from previous runs for regression detection")
         publish_event(run_id, "agent_start", {"agent": "validator", "message": "Analyzing screenshots for bugs…"})
 
+        # Phase 1: Text-based analysis of test steps
         for step in test_steps:
             if step.get("action") in ("observe", "errors_detected"):
                 new_bugs = self._analyze_step(step, known_bugs)
@@ -107,8 +177,34 @@ If no bugs found, return an empty array [].
                             "message": f"[{bug.get('severity','medium').upper()}] {bug.get('title','Bug detected')}",
                         })
 
+        # Phase 2: Vision-based analysis of screenshots (multimodal)
+        # Only analyze screenshots that still have base64 data
+        visual_screenshots = [s for s in screenshots if s.get("base64")]
+        if visual_screenshots:
+            logger.info(f"Running vision analysis on {len(visual_screenshots)} screenshot(s)")
+            publish_event(run_id, "agent_progress", {
+                "agent": "validator",
+                "message": f"Running visual inspection on {len(visual_screenshots)} screenshot(s)…",
+            })
+            for shot in visual_screenshots:
+                if check_run_control(run_id) == SIGNAL_STOP:
+                    break
+                visual_bugs = self._analyze_screenshot_visual(shot, known_bugs)
+                if visual_bugs:
+                    logger.info(f"Vision found {len(visual_bugs)} visual bug(s) on {shot.get('url', '?')}")
+                    bugs_found.extend(visual_bugs)
+                    for bug in visual_bugs:
+                        publish_event(run_id, "bug_found", {
+                            "title": bug.get("title", "Visual bug"),
+                            "severity": bug.get("severity", "medium"),
+                            "page_url": bug.get("page_url", shot.get("url", "")),
+                            "message": f"[VISUAL] {bug.get('title','Visual bug')}",
+                        })
+        else:
+            logger.debug("No screenshots with base64 data available for vision analysis")
+
         logger.info(f"ValidatorAgent total bugs found: {len(bugs_found)}")
-        publish_event(run_id, "agent_done", {"agent": "validator", "message": f"Validation complete — {len(bugs_found)} functional bug(s)"})
+        publish_event(run_id, "agent_done", {"agent": "validator", "message": f"Validation complete — {len(bugs_found)} bug(s) (text + visual)"})
 
         return {
             **state,

--- a/agent/graph/graph.py
+++ b/agent/graph/graph.py
@@ -9,7 +9,9 @@ from .nodes import (
     explorer_node,
     orchestrator_node,
     reporter_node,
+    route_reporter,
     security_node,
+    simple_reporter_node,
     validator_node,
 )
 from .state import AgentState
@@ -25,16 +27,21 @@ def build_graph():
     graph.add_node("validator", validator_node)
     graph.add_node("security", security_node)
     graph.add_node("reporter", reporter_node)
+    graph.add_node("simple_reporter", simple_reporter_node)
 
     # ── Set entry point ─────────────────────────────────────────────────────
     graph.set_entry_point("orchestrator")
 
     # ── Define edges ─────────────────────────────────────────────────────────
-    # Security always runs after validation — never skipped, regardless of bugs found
     graph.add_edge("orchestrator", "explorer")
     graph.add_edge("explorer", "validator")
     graph.add_edge("validator", "security")
-    graph.add_edge("security", "reporter")
+    # Route to full LLM reporter or quick logger based on test_config.detailed_report
+    graph.add_conditional_edges("security", route_reporter, {
+        "reporter": "reporter",
+        "simple_reporter": "simple_reporter",
+    })
     graph.add_edge("reporter", END)
+    graph.add_edge("simple_reporter", END)
 
     return graph.compile()

--- a/agent/graph/nodes.py
+++ b/agent/graph/nodes.py
@@ -24,7 +24,10 @@ def explorer_node(state: AgentState) -> AgentState:
     from agents.explorer import ExplorerAgent
 
     logger.info("[explorer] Starting browser exploration")
-    agent = ExplorerAgent()
+    credentials = state.get("credentials") or {}
+    extra_blocked = credentials.get("blocked_domains", []) if isinstance(credentials, dict) else []
+    allowed = credentials.get("allowed_domains", []) if isinstance(credentials, dict) else []
+    agent = ExplorerAgent(extra_blocked_domains=extra_blocked, allowed_domains=allowed)
     return agent.run(state)
 
 
@@ -67,3 +70,20 @@ def reporter_node(state: AgentState) -> AgentState:
     logger.info(f"[reporter] Reporting {len(state.get('bugs_found', []))} bugs")
     agent = ReporterAgent()
     return agent.run(state)
+
+
+def simple_reporter_node(state: AgentState) -> AgentState:
+    """Logs bugs without LLM enrichment (quick mode)."""
+    from agents.reporter import SimpleReporterAgent
+
+    logger.info(f"[reporter] Quick-logging {len(state.get('bugs_found', []))} bugs (no AI enrichment)")
+    agent = SimpleReporterAgent()
+    return agent.run(state)
+
+
+def route_reporter(state: AgentState) -> str:
+    """Route to the full LLM reporter or the simple logger based on test_config."""
+    test_config = state.get("test_config") or {}
+    if test_config.get("detailed_report", True):
+        return "reporter"
+    return "simple_reporter"

--- a/agent/graph/state.py
+++ b/agent/graph/state.py
@@ -36,3 +36,21 @@ class AgentState(TypedDict):
 
     # Final structured report (populated by ReporterAgent)
     report: Optional[List[Dict[str, Any]]]
+
+    # Per-app persistent memory loaded from PostgreSQL before each run.
+    # None when no memory exists yet (first run for this app).
+    app_memory: Optional[Dict[str, Any]]
+
+    # Login steps produced by a successful smart login this run.
+    # Populated by ExplorerAgent; consumed by extract_memory_updates() to
+    # persist the working flow so future runs can skip LLM login discovery.
+    login_steps_for_memory: Optional[List[Dict[str, Any]]]
+
+    # Parsed orchestrator output (pages, journeys, focus_areas, notes) — drives explorer priorities.
+    strategic_plan: Optional[Dict[str, Any]]
+
+    # URLs visited during exploration — consumed by SecurityAgent for multi-page scans.
+    visited_urls: Optional[List[str]]
+
+    # Populated by ReporterAgent after deduplicating bugs_found.
+    dedupe_stats: Optional[Dict[str, Any]]

--- a/agent/graph/state.py
+++ b/agent/graph/state.py
@@ -33,3 +33,8 @@ class AgentState(TypedDict):
 
     # Final structured report (populated by ReporterAgent)
     report: Optional[List[Dict[str, Any]]]
+
+    # Memory & Skills (populated by runner before pipeline starts)
+    memory: Optional[Dict[str, Any]]       # Historical context for this app
+    skills: Optional[List[Dict[str, Any]]] # Relevant learned patterns
+    app_id: Optional[str]                  # App ID for memory lookups

--- a/agent/graph/state.py
+++ b/agent/graph/state.py
@@ -31,5 +31,8 @@ class AgentState(TypedDict):
     error: Optional[str]
     status: str  # "pending" | "running" | "completed" | "failed"
 
+    # Test configuration supplied by the user at run-creation time
+    test_config: Optional[Dict[str, Any]]  # {max_pages, instructions, focus_areas}
+
     # Final structured report (populated by ReporterAgent)
     report: Optional[List[Dict[str, Any]]]

--- a/agent/tools/browser.py
+++ b/agent/tools/browser.py
@@ -4,24 +4,54 @@ Playwright wrapper providing a simple API for the agent pipeline.
 """
 
 import logging
+import time
 from typing import List, Optional
 
 from playwright.sync_api import Page, sync_playwright
 
 logger = logging.getLogger("bughunter.browser")
 
+# Consent/analytics CDN domains to block by default.
+# These are never needed for QA testing and their absence prevents banners from loading.
+DEFAULT_BLOCKED_DOMAINS: List[str] = [
+    "trustarc.com",
+    "truste.com",
+    "cookielaw.org",      # OneTrust CDN
+    "onetrust.com",
+    "cookiebot.com",
+    "usercentrics.com",
+    "quantcast.com",
+    "consent.cookiefirst.com",
+    "cdn.privacy-mgmt.com",
+]
+
 
 class BrowserTool:
     """Synchronous Playwright browser wrapper for web automation."""
 
-    def __init__(self, headless: bool = True):
+    def __init__(
+        self,
+        headless: bool = True,
+        extra_blocked_domains: List[str] = None,
+        allowed_domains: List[str] = None,
+    ):
         self.headless = headless
+        self._extra_blocked_domains: List[str] = extra_blocked_domains or []
+        self._allowed_domains: List[str] = allowed_domains or []
         self._playwright = None
         self._browser = None
         self._context = None
         self.page: Optional[Page] = None
         self._console_errors: List[str] = []
         self._network_errors: List[str] = []
+        self._api_responses: List[dict] = []
+        self._intentionally_blocked: set = set()
+        self._request_start: dict = {}  # id(request) → perf_counter start time
+        self._static_exts = (
+            '.js', '.css', '.png', '.jpg', '.jpeg', '.gif', '.webp', '.avif',
+            '.woff', '.woff2', '.ttf', '.otf', '.eot', '.svg', '.ico',
+            '.mp4', '.webm', '.ogg', '.wav', '.map',
+        )
 
     def start(self):
         """Launch the browser and create a new page."""
@@ -31,16 +61,75 @@ class BrowserTool:
             viewport={"width": 1280, "height": 800},
             user_agent="BugHunter.AI/1.0 (QA Bot)",
         )
+
+        # Block consent CDN domains so banners never load — this is the most
+        # reliable way to prevent high-z-index overlays from appearing at all.
+        # allowed_domains overrides the default block list (e.g. for SSO-dependent apps).
+        all_blocked = [
+            d for d in DEFAULT_BLOCKED_DOMAINS + self._extra_blocked_domains
+            if not any(allowed in d or d in allowed for allowed in self._allowed_domains)
+        ]
+        if all_blocked:
+            blocked_set = set(all_blocked)
+            self._intentionally_blocked = blocked_set
+
+            def _handle_route(route):
+                if any(d in route.request.url for d in blocked_set):
+                    logger.debug(f"Blocked consent CDN: {route.request.url}")
+                    route.abort()
+                else:
+                    route.continue_()
+
+            self._context.route("**/*", _handle_route)
+            logger.info(
+                f"Blocking {len(all_blocked)} consent/analytics domains"
+                + (f" (allowed override: {self._allowed_domains})" if self._allowed_domains else "")
+            )
+
         self.page = self._context.new_page()
 
         # Capture console errors
         self.page.on("console", lambda msg: self._console_errors.append(msg.text) if msg.type == "error" else None)
 
-        # Capture failed network requests
-        self.page.on(
-            "requestfailed",
-            lambda req: self._network_errors.append(f"{req.method} {req.url} → {req.failure}"),
-        )
+        # Capture failed network requests, excluding domains we intentionally blocked.
+        def _on_request_failed(req):
+            if self._intentionally_blocked and any(d in req.url for d in self._intentionally_blocked):
+                return
+            self._network_errors.append(f"{req.method} {req.url} → {req.failure}")
+
+        self.page.on("requestfailed", _on_request_failed)
+
+        # Track request start times via wall clock so duration is always accurate.
+        # Playwright's HAR-based timing object has many "not ready yet" edge cases
+        # (responseEnd is 0 or -1 when the response event fires) which cause negatives.
+        def _on_request(req):
+            url = req.url
+            if any(url.endswith(ext) or f'{ext}?' in url for ext in self._static_exts):
+                return
+            if self._intentionally_blocked and any(d in url for d in self._intentionally_blocked):
+                return
+            self._request_start[id(req)] = time.perf_counter()
+
+        def _on_response(resp):
+            url = resp.url
+            if any(url.endswith(ext) or f'{ext}?' in url for ext in self._static_exts):
+                return
+            if self._intentionally_blocked and any(d in url for d in self._intentionally_blocked):
+                return
+            try:
+                start = self._request_start.pop(id(resp.request), None)
+                duration_ms = round((time.perf_counter() - start) * 1000) if start is not None else 0
+                self._api_responses.append({
+                    "url": url,
+                    "method": resp.request.method,
+                    "status": resp.status,
+                    "duration_ms": duration_ms,
+                })
+            except Exception:
+                pass
+
+        self.page.on("request", _on_request)
+        self.page.on("response", _on_response)
 
         logger.debug("Browser started")
 
@@ -50,6 +139,8 @@ class BrowserTool:
             raise RuntimeError("Browser not started. Call start() first.")
         self._console_errors.clear()
         self._network_errors.clear()
+        self._api_responses.clear()
+        self._request_start.clear()
         self.page.goto(url, wait_until=wait_until, timeout=60_000)
         logger.debug(f"Navigated to: {url}")
 
@@ -136,7 +227,7 @@ class BrowserTool:
             const ids = [
                 'consent_blackbar', 'onetrust-banner-sdk',
                 'CybotCookiebotDialog', 'truste-consent-track',
-                'trustarc-banner-overlay',
+                'trustarc-banner-overlay', 'trustarc-consent-track',
             ];
             for (const id of ids) {
                 const el = document.getElementById(id);
@@ -147,24 +238,38 @@ class BrowserTool:
             document.querySelectorAll(
                 '.truste_box_overlay, .truste_popframe, .truste_overlay, ' +
                 '[id^="pop-div"], [id^="pop-frame"], ' +
-                'iframe[name="trustarc_cm"]'
+                'iframe[name="trustarc_cm"], iframe[id^="trustarc"]'
             ).forEach(el => {
                 const desc = el.id || el.className || el.tagName;
                 el.remove();
                 removed.push(desc);
             });
 
-            // 3. Remove any remaining full-screen overlays that block pointer events
-            document.querySelectorAll(
-                '[class*="overlay"], [class*="Overlay"]'
-            ).forEach(el => {
+            // 3. Nuclear option: remove any fixed/absolute element with extreme z-index
+            // (TrustArc uses 21999998 — nothing in a legitimate app UI needs > 999999).
+            // Skip elements that contain form inputs so we don't accidentally remove login modals.
+            document.querySelectorAll('*').forEach(el => {
                 const style = window.getComputedStyle(el);
-                const isFullScreen = (
-                    style.position === 'fixed' &&
-                    parseInt(style.zIndex || 0) > 100
-                );
-                if (isFullScreen) {
-                    const desc = el.id || el.className || el.tagName;
+                const z = parseInt(style.zIndex) || 0;
+                if (z > 999999 &&
+                    (style.position === 'fixed' || style.position === 'absolute')) {
+                    if (!el.querySelector('input, textarea, select, button[type="submit"]')) {
+                        const desc = (el.id || el.className || el.tagName).toString().slice(0, 60);
+                        el.remove();
+                        removed.push('z:' + z + ' ' + desc);
+                    }
+                }
+            });
+
+            // 4. Restore body scroll/pointer-events if locked by a banner
+            document.body.style.overflow = '';
+            document.body.style.pointerEvents = '';
+            document.documentElement.style.overflow = '';
+
+            // 5. Remove Angular CDK overlay backdrops (Angular Material)
+            document.querySelectorAll('.cdk-overlay-container, .cdk-overlay-backdrop').forEach(el => {
+                if (!el.querySelector('input, textarea')) {
+                    const desc = el.className.slice(0, 40);
                     el.remove();
                     removed.push(desc);
                 }
@@ -203,6 +308,24 @@ class BrowserTool:
         """Return captured network failure messages."""
         return list(self._network_errors)
 
+    def get_page_load_time(self) -> int:
+        """Return page load time in ms using the Navigation Timing API. Returns 0 on error."""
+        if not self.page:
+            return 0
+        try:
+            return self.page.evaluate(
+                "() => { const t = window.performance.timing; "
+                "return t.loadEventEnd > 0 ? t.loadEventEnd - t.navigationStart : 0; }"
+            )
+        except Exception:
+            return 0
+
+    def get_api_response_times(self) -> List[dict]:
+        """Return captured API response records and clear the internal list."""
+        result = list(self._api_responses)
+        self._api_responses.clear()
+        return result
+
     def get_all_links(self) -> List[str]:
         """Return all href links on the current page."""
         if not self.page:
@@ -212,6 +335,61 @@ class BrowserTool:
                 "a[href]",
                 "els => els.map(el => el.href)",
             )
+        except Exception:
+            return []
+
+    def get_clickable_elements(self) -> List[dict]:
+        """Return visible interactive elements (buttons, tabs, menu/nav items) with their text and selector.
+
+        Excludes destructive actions (delete, logout, etc.) and disabled elements.
+        Used by the explorer to discover page functionality beyond <a href> links.
+        """
+        if not self.page:
+            return []
+        try:
+            return self.page.evaluate("""() => {
+                const SKIP = /\\b(delete|remove|reset|clear|cancel|logout|sign.?out|close|dismiss|decline|reject|deactivate|archive)\\b/i;
+                const seen = new Set();
+                const results = [];
+
+                const candidates = document.querySelectorAll(
+                    'button:not([disabled]):not([type="submit"]):not([type="reset"]), ' +
+                    '[role="button"]:not([disabled]), ' +
+                    '[role="tab"], [role="menuitem"], [role="option"], ' +
+                    'nav a[href], header a[href], ' +
+                    '[class*="sidebar"] a[href], [class*="nav"] a[href], [class*="menu"] a[href]'
+                );
+
+                candidates.forEach(el => {
+                    const rect = el.getBoundingClientRect();
+                    if (!rect.width || !rect.height) return;
+                    const style = window.getComputedStyle(el);
+                    if (style.display === 'none' || style.visibility === 'hidden') return;
+
+                    const text = (
+                        el.innerText || el.textContent ||
+                        el.getAttribute('aria-label') || el.getAttribute('title') || ''
+                    ).trim().replace(/\\s+/g, ' ').slice(0, 80);
+
+                    if (!text || SKIP.test(text) || seen.has(text)) return;
+                    seen.add(text);
+
+                    const id = el.id ? '#' + el.id : null;
+                    const testId = el.getAttribute('data-testid')
+                        ? '[data-testid="' + el.getAttribute('data-testid') + '"]' : null;
+                    const href = el.getAttribute('href') || null;
+
+                    results.push({
+                        text,
+                        selector: id || testId || null,
+                        href,
+                        role: el.getAttribute('role') || el.tagName.toLowerCase(),
+                        tag: el.tagName.toLowerCase(),
+                    });
+                });
+
+                return results.slice(0, 20);
+            }""")
         except Exception:
             return []
 
@@ -240,6 +418,110 @@ class BrowserTool:
             )
         except Exception:
             return []
+
+    def inspect_page_structure(self) -> dict:
+        """Return structured page data ported from web-scrapper extractor.ts patterns.
+
+        Runs DOM queries directly in the browser via page.evaluate() — no extra
+        Python dependencies. Returns a dict with:
+          metadata:   {title, description, headings: [{level, text}]}
+          forms:      [{action, method, fields: [{name, type, label, required, placeholder}]}]
+          tables:     [{headers: [...], row_count: int}]
+          key_values: {label: value, ...}
+        """
+        if not self.page:
+            return {}
+        try:
+            return self.page.evaluate("""() => {
+                try {
+                    const txt = el => (el.textContent || '').trim().replace(/\\s+/g, ' ');
+
+                    // Headings (from extractMetadata)
+                    const headings = [];
+                    document.querySelectorAll('h1,h2,h3,h4,h5,h6').forEach(el => {
+                        if (headings.length >= 10) return;
+                        const text = txt(el).slice(0, 100);
+                        if (text) headings.push({ level: parseInt(el.tagName[1]), text });
+                    });
+                    const metadata = {
+                        title: document.title.trim(),
+                        description: (
+                            document.querySelector('meta[name="description"]')?.content ||
+                            document.querySelector('meta[property="og:description"]')?.content ||
+                            null
+                        ),
+                        headings,
+                    };
+
+                    // Forms with fields (from extractForms)
+                    const forms = [];
+                    document.querySelectorAll('form').forEach(formEl => {
+                        if (forms.length >= 5) return;
+                        const fields = [];
+                        formEl.querySelectorAll('input,select,textarea').forEach(el => {
+                            if (fields.length >= 15) return;
+                            const name = el.name || el.id;
+                            if (!name) return;
+                            const type = (el.type || el.tagName).toLowerCase();
+                            if (['hidden','submit','button','image','reset'].includes(type)) return;
+                            let label = null;
+                            if (el.id) {
+                                const lbl = document.querySelector('label[for="' + el.id + '"]');
+                                if (lbl) label = txt(lbl).slice(0, 80);
+                            }
+                            if (!label && el.previousElementSibling?.tagName === 'LABEL')
+                                label = txt(el.previousElementSibling).slice(0, 80);
+                            if (!label && el.closest('label')) {
+                                const clone = el.closest('label').cloneNode(true);
+                                clone.querySelectorAll('input,select,textarea').forEach(c => c.remove());
+                                label = (clone.textContent || '').trim().replace(/\\s+/g, ' ').slice(0, 80) || null;
+                            }
+                            fields.push({
+                                name: name.slice(0, 60), type,
+                                label: label || null,
+                                required: el.required || el.getAttribute('aria-required') === 'true',
+                                placeholder: (el.placeholder || '').slice(0, 80) || null,
+                            });
+                        });
+                        forms.push({ action: formEl.action || null, method: (formEl.method || 'get').toLowerCase(), fields });
+                    });
+
+                    // Tables (from extractTables)
+                    const tables = [];
+                    document.querySelectorAll('table').forEach(tableEl => {
+                        if (tables.length >= 5) return;
+                        const headers = [];
+                        const headerRow = tableEl.querySelector('thead tr') || tableEl.querySelector('tr');
+                        if (headerRow) headerRow.querySelectorAll('th,td').forEach(c => headers.push(txt(c).slice(0, 60)));
+                        const rowCount = tableEl.querySelectorAll('tbody tr').length ||
+                            Math.max(0, tableEl.querySelectorAll('tr').length - 1);
+                        if (headers.length > 0 || rowCount > 0) tables.push({ headers, row_count: rowCount });
+                    });
+
+                    // Key-value pairs (from extractKeyValuePairs)
+                    const key_values = {};
+                    let kvCount = 0;
+                    document.querySelectorAll('dl').forEach(dl => {
+                        let lastKey = null;
+                        dl.querySelectorAll('dt,dd').forEach(el => {
+                            if (kvCount >= 20) return;
+                            const t = txt(el).slice(0, 80);
+                            if (el.tagName === 'DT') { lastKey = t; }
+                            else if (el.tagName === 'DD' && lastKey) { key_values[lastKey] = t; lastKey = null; kvCount++; }
+                        });
+                    });
+                    document.querySelectorAll('[class*="label"],[class*="key"]').forEach(el => {
+                        if (kvCount >= 20) return;
+                        const key = txt(el).slice(0, 80);
+                        const next = el.nextElementSibling;
+                        if (key && next) { key_values[key] = txt(next).slice(0, 120); kvCount++; }
+                    });
+
+                    return { metadata, forms, tables, key_values };
+                } catch(e) { return { error: e.message }; }
+            }""")
+        except Exception:
+            return {}
 
     def close(self):
         """Close the browser and cleanup resources."""

--- a/agent/tools/bug_dedupe.py
+++ b/agent/tools/bug_dedupe.py
@@ -1,8 +1,14 @@
-"""Merge duplicate bug observations before structured reporting."""
+"""Merge duplicate bug observations before structured reporting.
+
+Uses both exact fingerprint matching AND semantic similarity to catch
+bugs that describe the same issue with different wording.
+"""
 
 from __future__ import annotations
 
 import logging
+import re
+from difflib import SequenceMatcher
 from typing import Any, Dict, List, Tuple
 
 from tools.memory import make_fingerprint
@@ -10,30 +16,101 @@ from tools.memory import make_fingerprint
 logger = logging.getLogger("bughunter.bug_dedupe")
 
 
-def dedupe_bugs(bugs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+def _normalize(text: str) -> str:
+    """Lowercase, strip whitespace, collapse runs of whitespace."""
+    return re.sub(r"\s+", " ", (text or "").lower().strip())
+
+
+def _semantic_similarity(a: str, b: str) -> float:
+    """Compute semantic similarity between two strings using SequenceMatcher.
+
+    Returns a float in [0.0, 1.0]. For short QA titles this is surprisingly
+    effective at catching rephrasings like:
+      "Login button broken" vs "Login button not working"
     """
-    Remove duplicates by fingerprint (title + page_url).
-    Preserves first occurrence order.
+    na, nb = _normalize(a), _normalize(b)
+    if not na or not nb:
+        return 0.0
+    return SequenceMatcher(None, na, nb).ratio()
+
+
+def _is_duplicate(bug: dict, existing: dict, threshold: float = 0.70) -> bool:
+    """Check if two bugs describe the same issue.
+
+    Uses a combination of:
+    1. Exact fingerprint match (title + page_url SHA-256)
+    2. Same page_url + high title similarity
+    3. Same page_url + same type + high description similarity
+    """
+    # Exact fingerprint match
+    fp_new = make_fingerprint(
+        (bug.get("title") or "").strip(),
+        (bug.get("page_url") or "").strip(),
+    )
+    fp_existing = make_fingerprint(
+        (existing.get("title") or "").strip(),
+        (existing.get("page_url") or "").strip(),
+    )
+    if fp_new == fp_existing:
+        return True
+
+    # Same page — check title similarity
+    page_a = _normalize(bug.get("page_url", ""))
+    page_b = _normalize(existing.get("page_url", ""))
+    if page_a and page_a == page_b:
+        title_sim = _semantic_similarity(bug.get("title", ""), existing.get("title", ""))
+        if title_sim >= threshold:
+            return True
+
+        # Same page + same type — check description similarity
+        if bug.get("type") == existing.get("type"):
+            desc_sim = _semantic_similarity(bug.get("description", ""), existing.get("description", ""))
+            if desc_sim >= threshold:
+                return True
+
+    return False
+
+
+def dedupe_bugs(bugs: List[Dict[str, Any]], threshold: float = 0.70) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Remove duplicates using exact fingerprints AND semantic similarity.
+
+    Preserves first occurrence order. Merges severity (keeps highest).
     """
     if not bugs:
-        return [], {"before": 0, "after": 0, "removed": 0}
+        return [], {"before": 0, "after": 0, "removed": 0, "semantic_removed": 0}
 
-    seen: set[str] = set()
+    severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
     merged: List[Dict[str, Any]] = []
-    for b in bugs:
-        title = (b.get("title") or "").strip()
-        page = (b.get("page_url") or "").strip()
-        fp = make_fingerprint(title, page)
-        if fp in seen:
-            continue
-        seen.add(fp)
-        merged.append(b)
+    semantic_removed = 0
+
+    for bug in bugs:
+        is_dup = False
+        for existing in merged:
+            if _is_duplicate(bug, existing, threshold):
+                is_dup = True
+                # Keep the higher severity
+                bug_sev = severity_order.get(bug.get("severity", "medium"), 2)
+                existing_sev = severity_order.get(existing.get("severity", "medium"), 2)
+                if bug_sev < existing_sev:
+                    existing["severity"] = bug.get("severity", "medium")
+                # Check if this was a semantic match (not exact fingerprint)
+                fp_new = make_fingerprint((bug.get("title") or "").strip(), (bug.get("page_url") or "").strip())
+                fp_existing = make_fingerprint((existing.get("title") or "").strip(), (existing.get("page_url") or "").strip())
+                if fp_new != fp_existing:
+                    semantic_removed += 1
+                break
+        if not is_dup:
+            merged.append(bug)
 
     stats = {
         "before": len(bugs),
         "after": len(merged),
         "removed": len(bugs) - len(merged),
+        "semantic_removed": semantic_removed,
     }
     if stats["removed"]:
-        logger.info(f"Deduped bugs: {stats['before']} → {stats['after']} (removed {stats['removed']})")
+        logger.info(
+            f"Deduped bugs: {stats['before']} → {stats['after']} "
+            f"(removed {stats['removed']}, {semantic_removed} by semantic similarity)"
+        )
     return merged, stats

--- a/agent/tools/bug_dedupe.py
+++ b/agent/tools/bug_dedupe.py
@@ -1,0 +1,39 @@
+"""Merge duplicate bug observations before structured reporting."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Tuple
+
+from tools.memory import make_fingerprint
+
+logger = logging.getLogger("bughunter.bug_dedupe")
+
+
+def dedupe_bugs(bugs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """
+    Remove duplicates by fingerprint (title + page_url).
+    Preserves first occurrence order.
+    """
+    if not bugs:
+        return [], {"before": 0, "after": 0, "removed": 0}
+
+    seen: set[str] = set()
+    merged: List[Dict[str, Any]] = []
+    for b in bugs:
+        title = (b.get("title") or "").strip()
+        page = (b.get("page_url") or "").strip()
+        fp = make_fingerprint(title, page)
+        if fp in seen:
+            continue
+        seen.add(fp)
+        merged.append(b)
+
+    stats = {
+        "before": len(bugs),
+        "after": len(merged),
+        "removed": len(bugs) - len(merged),
+    }
+    if stats["removed"]:
+        logger.info(f"Deduped bugs: {stats['before']} → {stats['after']} (removed {stats['removed']})")
+    return merged, stats

--- a/agent/tools/control.py
+++ b/agent/tools/control.py
@@ -1,0 +1,62 @@
+"""
+BugHunter.AI - Run Control
+Redis-backed signals for stopping and pausing active test runs.
+
+The backend writes a signal to Redis when the user clicks Stop or Pause.
+The agent reads it at each page boundary and reacts accordingly.
+"""
+
+import logging
+import os
+import time
+
+import redis
+
+logger = logging.getLogger("bughunter.control")
+
+SIGNAL_STOP  = "stop"
+SIGNAL_PAUSE = "pause"
+_KEY_PREFIX  = "bughunter:control:"
+_SIGNAL_TTL  = 3600  # 1-hour safety expiry so stale keys don't persist
+
+
+def _redis() -> redis.Redis:
+    url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    return redis.from_url(url, decode_responses=True)
+
+
+def check_run_control(run_id: str) -> str | None:
+    """Return the current control signal ('stop' | 'pause') for a run, or None."""
+    if not run_id:
+        return None
+    try:
+        return _redis().get(f"{_KEY_PREFIX}{run_id}")
+    except Exception as exc:
+        logger.debug(f"control.check failed for {run_id}: {exc}")
+        return None
+
+
+def clear_run_control(run_id: str) -> None:
+    """Remove the control signal key once the run has finished."""
+    if not run_id:
+        return
+    try:
+        _redis().delete(f"{_KEY_PREFIX}{run_id}")
+    except Exception as exc:
+        logger.debug(f"control.clear failed for {run_id}: {exc}")
+
+
+def wait_while_paused(run_id: str, poll_interval: float = 2.0) -> bool:
+    """
+    Block until the run is no longer paused.
+
+    Returns True if a stop signal was received while waiting (caller should break),
+    False if the run was resumed normally.
+    """
+    logger.info(f"Run {run_id} paused — waiting for resume or stop signal…")
+    while True:
+        signal = check_run_control(run_id)
+        if signal != SIGNAL_PAUSE:
+            # Either resumed (None) or stopped
+            return signal == SIGNAL_STOP
+        time.sleep(poll_interval)

--- a/agent/tools/json_utils.py
+++ b/agent/tools/json_utils.py
@@ -1,0 +1,20 @@
+"""Extract JSON from LLM responses (markdown fences, extra prose)."""
+
+import re
+
+
+def extract_json_from_text(text: str) -> str:
+    """Strip markdown fences and extract first JSON object or array from LLM output."""
+    text = re.sub(r"```(?:json)?\s*", "", text).strip().rstrip("`").strip()
+    for start_char, end_char in [("{", "}"), ("[", "]")]:
+        idx = text.find(start_char)
+        if idx != -1:
+            depth = 0
+            for i, ch in enumerate(text[idx:], idx):
+                if ch == start_char:
+                    depth += 1
+                elif ch == end_char:
+                    depth -= 1
+                    if depth == 0:
+                        return text[idx : i + 1]
+    return text

--- a/agent/tools/memory.py
+++ b/agent/tools/memory.py
@@ -1,0 +1,201 @@
+"""
+BugHunter.AI - App Memory
+Per-app persistent memory stored in PostgreSQL.
+
+Loads before each run, updated after each successful run.
+All functions are safe on first run (no row yet → returns {}).
+"""
+
+import copy
+import hashlib
+import json
+import logging
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+
+from tools.storage import _get_conn  # reuse the existing connection pool
+
+logger = logging.getLogger("bughunter.memory")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_memory(app_id: str) -> dict:
+    """Load the memory blob for an app. Returns {} on first run or any error."""
+    try:
+        with _get_conn() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT data FROM app_memory WHERE app_id = %s", (app_id,))
+            row = cur.fetchone()
+            cur.close()
+            return row[0] if row else {}
+    except Exception as exc:
+        logger.error(f"load_memory failed for app {app_id}: {exc}")
+        return {}
+
+
+def save_memory(app_id: str, memory: dict) -> bool:
+    """
+    Upsert the memory blob for an app.
+    Creates the row on first run, updates it on subsequent runs.
+    Returns True on success, False on failure (non-fatal).
+    """
+    try:
+        with _get_conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO app_memory (app_id, data)
+                VALUES (%s, %s)
+                ON CONFLICT (app_id) DO UPDATE
+                  SET data = EXCLUDED.data,
+                      updated_at = NOW()
+                """,
+                (app_id, json.dumps(memory)),
+            )
+            conn.commit()
+            cur.close()
+        logger.info(f"Memory saved for app {app_id}")
+        return True
+    except Exception as exc:
+        logger.error(f"save_memory failed for app {app_id}: {exc}")
+        return False
+
+
+def make_fingerprint(title: str, page_url: str) -> str:
+    """
+    Stable bug identity: SHA-256 of (title + page_url), both normalised.
+    Used to detect the same bug across multiple runs (regression detection).
+    """
+    normalised = (title.lower().strip() + page_url.lower().strip()).encode()
+    return hashlib.sha256(normalised).hexdigest()
+
+
+def build_page_priority_list(memory: dict, base_url: str) -> List[str]:
+    """
+    Return bug-prone page URLs from memory sorted descending by priority_score,
+    filtered to the same origin as base_url.
+
+    Called by ExplorerAgent to visit historically buggy pages first.
+    """
+    try:
+        base_origin = _origin(base_url)
+        pages = memory.get("pages", {})
+        same_origin = [
+            (url, info)
+            for url, info in pages.items()
+            if _origin(url) == base_origin and info.get("bug_count", 0) > 0
+        ]
+        same_origin.sort(key=lambda kv: kv[1].get("priority_score", 0), reverse=True)
+        return [url for url, _ in same_origin]
+    except Exception as exc:
+        logger.debug(f"build_page_priority_list error: {exc}")
+        return []
+
+
+def extract_memory_updates(state: Dict[str, Any], existing_memory: dict) -> dict:
+    """
+    Pure function — no DB calls.
+    Takes a completed AgentState and the memory loaded at run start.
+    Returns the new memory dict that should be saved.
+
+    Handles:
+    1. Login steps from a successful smart login
+    2. Page priority scores from bugs found
+    3. Known-bug deduplication via fingerprints
+    4. Run metadata (total_runs, last_run_id)
+    """
+    memory = copy.deepcopy(existing_memory) if existing_memory else {}
+    run_id = state.get("run_id", "")
+    report: List[Dict] = state.get("report") or []
+
+    # ------------------------------------------------------------------
+    # 1. Login steps
+    # ------------------------------------------------------------------
+    login_steps = state.get("login_steps_for_memory")
+    if login_steps:
+        memory["login"] = {
+            "working_steps": login_steps,
+            "last_success_run_id": run_id,
+            "failure_count": 0,
+        }
+    elif memory.get("login", {}).get("working_steps"):
+        # Memory-based login was attempted.
+        # If smart_login_completed appears in test_steps it means stored steps
+        # failed and the agent fell back to smart login.
+        had_smart_fallback = any(
+            s.get("action") == "smart_login_completed"
+            for s in (state.get("test_steps") or [])
+        )
+        if had_smart_fallback:
+            memory["login"]["failure_count"] = memory["login"].get("failure_count", 0) + 1
+
+    # ------------------------------------------------------------------
+    # 2. Page priority scores
+    # ------------------------------------------------------------------
+    pages: dict = memory.setdefault("pages", {})
+    for bug in report:
+        page_url = (bug.get("page_url") or "").strip()
+        if not page_url:
+            continue
+        if page_url not in pages:
+            pages[page_url] = {"bug_count": 0, "priority_score": 0, "last_visited_run_id": run_id}
+        pages[page_url]["bug_count"] = pages[page_url].get("bug_count", 0) + 1
+        pages[page_url]["last_visited_run_id"] = run_id
+        pages[page_url]["priority_score"] = pages[page_url]["bug_count"]
+
+    # ------------------------------------------------------------------
+    # 3. Known bugs (dedup by fingerprint)
+    # ------------------------------------------------------------------
+    known_bugs: list = memory.setdefault("known_bugs", [])
+    fp_to_idx = {b["fingerprint"]: i for i, b in enumerate(known_bugs)}
+
+    for bug in report:
+        fp = make_fingerprint(bug.get("title", ""), bug.get("page_url", ""))
+        if fp in fp_to_idx:
+            idx = fp_to_idx[fp]
+            known_bugs[idx]["last_seen_run_id"] = run_id
+            known_bugs[idx]["occurrence_count"] = known_bugs[idx].get("occurrence_count", 1) + 1
+        else:
+            entry = {
+                "fingerprint": fp,
+                "title": bug.get("title", ""),
+                "page_url": bug.get("page_url", ""),
+                "severity": bug.get("severity", "medium"),
+                "type": bug.get("type", "functional"),
+                "first_seen_run_id": run_id,
+                "last_seen_run_id": run_id,
+                "occurrence_count": 1,
+            }
+            fp_to_idx[fp] = len(known_bugs)
+            known_bugs.append(entry)
+
+    # Cap at 100 entries; evict those with the oldest last_seen_run_id
+    if len(known_bugs) > 100:
+        known_bugs.sort(key=lambda b: b.get("last_seen_run_id", ""), reverse=False)
+        memory["known_bugs"] = known_bugs[-100:]
+
+    # ------------------------------------------------------------------
+    # 4. Run metadata
+    # ------------------------------------------------------------------
+    memory["total_runs"] = memory.get("total_runs", 0) + 1
+    memory["last_run_id"] = run_id
+
+    return memory
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _origin(url: str) -> str:
+    """Return scheme://host for a URL, or the full URL if parsing fails."""
+    try:
+        p = urlparse(url)
+        return f"{p.scheme}://{p.netloc}"
+    except Exception:
+        return url

--- a/agent/tools/memory.py
+++ b/agent/tools/memory.py
@@ -1,0 +1,398 @@
+"""
+BugHunter.AI - Memory & Skills Service
+Loads historical context and learned patterns for agent self-improvement.
+"""
+
+import json
+import logging
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+import psycopg2.extras
+
+from tools.storage import _get_conn
+
+logger = logging.getLogger("bughunter.memory")
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+def get_app_id_for_run(run_id: str) -> Optional[str]:
+    """Query test_runs to get app_id for a given run_id."""
+    try:
+        with _get_conn() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT app_id FROM test_runs WHERE id = %s", (run_id,))
+            row = cur.fetchone()
+            cur.close()
+            return str(row[0]) if row else None
+    except Exception as exc:
+        logger.error(f"get_app_id_for_run failed: {exc}")
+        return None
+
+
+def get_previous_bugs_for_app(app_id: str, limit: int = 50) -> List[Dict[str, Any]]:
+    """Fetch bug reports from previous runs for the same app."""
+    try:
+        with _get_conn() as conn:
+            cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+            cur.execute(
+                """
+                SELECT id, run_id, title, description, severity, status, page_url
+                FROM bug_reports
+                WHERE app_id = %s
+                ORDER BY created_at DESC
+                LIMIT %s
+                """,
+                (app_id, limit),
+            )
+            rows = cur.fetchall()
+            cur.close()
+            return [dict(r) for r in rows]
+    except Exception as exc:
+        logger.error(f"get_previous_bugs_for_app failed: {exc}")
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Memory loading
+# ---------------------------------------------------------------------------
+
+def load_app_memory(app_id: str, limit: int = 5) -> Dict[str, Any]:
+    """Load and merge recent memory entries for an app into a single context dict."""
+    try:
+        with _get_conn() as conn:
+            cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+            cur.execute(
+                """
+                SELECT buggy_pages, effective_strategies, navigation_map,
+                       security_findings, run_summary
+                FROM agent_memory
+                WHERE app_id = %s
+                ORDER BY created_at DESC
+                LIMIT %s
+                """,
+                (app_id, limit),
+            )
+            rows = cur.fetchall()
+            cur.close()
+    except Exception as exc:
+        logger.error(f"load_app_memory failed: {exc}")
+        return {}
+
+    if not rows:
+        return {}
+
+    # Merge across recent runs
+    all_buggy_pages: Dict[str, Dict] = {}
+    all_strategies: List[Dict] = []
+    all_security: List[Dict] = []
+    run_summaries: List[str] = []
+
+    for row in rows:
+        # Buggy pages — aggregate by URL
+        for page in (row.get("buggy_pages") or []):
+            url = page.get("url", "")
+            if url in all_buggy_pages:
+                all_buggy_pages[url]["bug_count"] += page.get("bug_count", 0)
+                all_buggy_pages[url]["bug_types"] = list(
+                    set(all_buggy_pages[url]["bug_types"]) | set(page.get("bug_types", []))
+                )
+            else:
+                all_buggy_pages[url] = {
+                    "url": url,
+                    "bug_count": page.get("bug_count", 0),
+                    "bug_types": page.get("bug_types", []),
+                    "severities": page.get("severities", []),
+                }
+
+        all_strategies.extend(row.get("effective_strategies") or [])
+        all_security.extend(row.get("security_findings") or [])
+
+        if row.get("run_summary"):
+            run_summaries.append(row["run_summary"])
+
+    # Sort buggy pages by bug count descending
+    sorted_pages = sorted(all_buggy_pages.values(), key=lambda p: p["bug_count"], reverse=True)
+
+    return {
+        "all_buggy_pages": sorted_pages[:10],
+        "past_strategies": all_strategies[:10],
+        "security_findings": all_security[:10],
+        "run_summaries": run_summaries[:5],
+        "previous_bugs": get_previous_bugs_for_app(app_id, limit=30),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Skills loading
+# ---------------------------------------------------------------------------
+
+def load_agent_skills(app_id: str, agent_type: str = "all", limit: int = 10) -> List[Dict[str, Any]]:
+    """Load relevant skills for an agent. Combines app-specific + global skills."""
+    try:
+        with _get_conn() as conn:
+            cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+            if agent_type == "all":
+                cur.execute(
+                    """
+                    SELECT agent_type, skill_type, description, skill_data, confidence
+                    FROM agent_skills
+                    WHERE app_id = %s OR app_id IS NULL
+                    ORDER BY confidence DESC, times_effective DESC
+                    LIMIT %s
+                    """,
+                    (app_id, limit),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT agent_type, skill_type, description, skill_data, confidence
+                    FROM agent_skills
+                    WHERE (app_id = %s OR app_id IS NULL) AND agent_type = %s
+                    ORDER BY confidence DESC, times_effective DESC
+                    LIMIT %s
+                    """,
+                    (app_id, agent_type, limit),
+                )
+            rows = cur.fetchall()
+            cur.close()
+            return [dict(r) for r in rows]
+    except Exception as exc:
+        logger.error(f"load_agent_skills failed: {exc}")
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Memory saving (post-run)
+# ---------------------------------------------------------------------------
+
+def save_run_memory(run_id: str, app_id: str, final_state: Dict[str, Any]) -> None:
+    """Extract and save memory from a completed run."""
+    try:
+        bugs = final_state.get("bugs_found", [])
+        test_steps = final_state.get("test_steps", [])
+        report = final_state.get("report", [])
+
+        # Build buggy_pages grouped by page_url
+        page_bugs: Dict[str, Dict] = defaultdict(lambda: {"bug_count": 0, "bug_types": set(), "severities": set()})
+        for bug in bugs:
+            url = bug.get("page_url", "unknown")
+            page_bugs[url]["bug_count"] += 1
+            page_bugs[url]["bug_types"].add(bug.get("type", "unknown"))
+            page_bugs[url]["severities"].add(bug.get("severity", "medium"))
+
+        buggy_pages = [
+            {"url": url, "bug_count": d["bug_count"], "bug_types": list(d["bug_types"]), "severities": list(d["severities"])}
+            for url, d in page_bugs.items()
+        ]
+
+        # Build navigation_map
+        visited_urls = list({s.get("url") for s in test_steps if s.get("url")})
+        login_success = any(s.get("action") == "login_flow_completed" for s in test_steps)
+        navigation_map = {
+            "visited_urls": visited_urls,
+            "login_success": login_success,
+            "pages_explored": len(visited_urls),
+        }
+
+        # Build security_findings
+        security_findings = []
+        for bug in bugs:
+            if bug.get("type") == "security":
+                security_findings.append({
+                    "type": "xss" if "XSS" in bug.get("title", "") else "sqli" if "SQL" in bug.get("title", "") else "secret",
+                    "payload": bug.get("payload", ""),
+                    "selector": bug.get("selector", ""),
+                    "effective": True,
+                    "page_url": bug.get("page_url", ""),
+                })
+
+        # Build run summary
+        run_summary = _generate_run_summary(final_state)
+
+        with _get_conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO agent_memory (app_id, run_id, buggy_pages, effective_strategies,
+                                          navigation_map, security_findings, run_summary)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    app_id,
+                    run_id,
+                    json.dumps(buggy_pages),
+                    json.dumps([]),  # strategies populated by skill extraction
+                    json.dumps(navigation_map),
+                    json.dumps(security_findings),
+                    run_summary,
+                ),
+            )
+            conn.commit()
+            cur.close()
+
+        logger.info(f"Saved run memory for run={run_id}, app={app_id}")
+    except Exception as exc:
+        logger.error(f"save_run_memory failed: {exc}", exc_info=True)
+
+
+def _generate_run_summary(final_state: Dict[str, Any]) -> str:
+    """Generate a concise run summary from final state."""
+    bugs = final_state.get("bugs_found", [])
+    steps = final_state.get("test_steps", [])
+    pages = len({s.get("url") for s in steps if s.get("url")})
+
+    bug_types = defaultdict(int)
+    severities = defaultdict(int)
+    for bug in bugs:
+        bug_types[bug.get("type", "unknown")] += 1
+        severities[bug.get("severity", "medium")] += 1
+
+    type_str = ", ".join(f"{count} {t}" for t, count in bug_types.items()) if bug_types else "none"
+    sev_str = ", ".join(f"{count} {s}" for s, count in severities.items()) if severities else "none"
+
+    return (
+        f"Explored {pages} page(s), found {len(bugs)} bug(s). "
+        f"Bug types: {type_str}. Severities: {sev_str}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Skills extraction (post-run)
+# ---------------------------------------------------------------------------
+
+def extract_and_save_skills(run_id: str, app_id: str, final_state: Dict[str, Any], memory: Dict[str, Any]) -> None:
+    """After a run, extract new skills or reinforce existing ones."""
+    try:
+        bugs = final_state.get("bugs_found", [])
+        previous_bugs = memory.get("previous_bugs", [])
+
+        # Track page_url → bug_type patterns
+        page_patterns: Dict[str, set] = defaultdict(set)
+        for bug in bugs:
+            page_patterns[bug.get("page_url", "")].add(bug.get("type", "unknown"))
+
+        with _get_conn() as conn:
+            cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+            # For each bug pattern, check if a matching skill exists
+            for page_url, bug_types in page_patterns.items():
+                for bug_type in bug_types:
+                    description = f"Page '{page_url}' tends to have {bug_type} bugs"
+
+                    cur.execute(
+                        """
+                        SELECT id, times_used, times_effective, confidence
+                        FROM agent_skills
+                        WHERE app_id = %s AND skill_type = 'bug_pattern'
+                          AND skill_data->>'page_url' = %s AND skill_data->>'bug_type' = %s
+                        """,
+                        (app_id, page_url, bug_type),
+                    )
+                    existing = cur.fetchone()
+
+                    if existing:
+                        new_confidence = min(1.0, existing["confidence"] + 0.1)
+                        cur.execute(
+                            """
+                            UPDATE agent_skills
+                            SET times_used = times_used + 1,
+                                times_effective = times_effective + 1,
+                                confidence = %s,
+                                updated_at = NOW()
+                            WHERE id = %s
+                            """,
+                            (new_confidence, existing["id"]),
+                        )
+                    else:
+                        cur.execute(
+                            """
+                            INSERT INTO agent_skills (app_id, agent_type, skill_type, description, skill_data, confidence)
+                            VALUES (%s, 'validator', 'bug_pattern', %s, %s, 0.5)
+                            """,
+                            (app_id, description, json.dumps({"page_url": page_url, "bug_type": bug_type})),
+                        )
+
+            # Save effective security payloads as skills
+            for bug in bugs:
+                if bug.get("type") == "security" and bug.get("payload"):
+                    payload = bug["payload"]
+                    sec_type = "xss" if "XSS" in bug.get("title", "") else "sqli"
+                    description = f"Effective {sec_type} payload: {payload[:50]}"
+
+                    cur.execute(
+                        """
+                        SELECT id FROM agent_skills
+                        WHERE app_id = %s AND skill_type = 'security_payload'
+                          AND skill_data->>'payload' = %s
+                        """,
+                        (app_id, payload),
+                    )
+                    if not cur.fetchone():
+                        cur.execute(
+                            """
+                            INSERT INTO agent_skills (app_id, agent_type, skill_type, description, skill_data, confidence)
+                            VALUES (%s, 'security', 'security_payload', %s, %s, 0.7)
+                            """,
+                            (app_id, description, json.dumps({"payload": payload, "type": sec_type})),
+                        )
+
+            conn.commit()
+            cur.close()
+
+        logger.info(f"Skills extracted for run={run_id}, app={app_id}")
+    except Exception as exc:
+        logger.error(f"extract_and_save_skills failed: {exc}", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting helpers
+# ---------------------------------------------------------------------------
+
+def format_memory_for_prompt(memory: Dict[str, Any], max_items: int = 5) -> str:
+    """Format memory into a concise string for LLM prompt injection."""
+    if not memory:
+        return ""
+
+    sections = []
+
+    run_summaries = memory.get("run_summaries", [])
+    if run_summaries:
+        sections.append("## Previous Run History (same app):")
+        for s in run_summaries[:3]:
+            sections.append(f"- {s}")
+
+    buggy_pages = memory.get("all_buggy_pages", [])
+    if buggy_pages:
+        sections.append("\n## Previously Buggy Pages:")
+        for p in buggy_pages[:max_items]:
+            types = ", ".join(p.get("bug_types", []))
+            sections.append(f"- {p['url']}: {p['bug_count']} bug(s) ({types})")
+
+    security = memory.get("security_findings", [])
+    if security:
+        sections.append("\n## Past Security Findings:")
+        for f in security[:max_items]:
+            sections.append(f"- {f.get('type', 'unknown')} on {f.get('page_url', '?')}")
+
+    return "\n".join(sections) if sections else ""
+
+
+def format_skills_for_prompt(skills: List[Dict[str, Any]], agent_type: str = "all") -> str:
+    """Format skills into a concise string for LLM prompt injection."""
+    if not skills:
+        return ""
+
+    filtered = [s for s in skills if agent_type == "all" or s.get("agent_type") == agent_type]
+    if not filtered:
+        return ""
+
+    lines = ["## Learned Patterns:"]
+    for skill in filtered[:5]:
+        conf = skill.get("confidence", 0.5)
+        lines.append(f"- [{conf:.0%} confidence] {skill['description']}")
+
+    return "\n".join(lines)

--- a/agent/tools/pipeline_log.py
+++ b/agent/tools/pipeline_log.py
@@ -1,0 +1,25 @@
+"""Compact pipeline timeline from test_steps for run summary / tuning."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def build_pipeline_log(test_steps: List[Dict[str, Any]], max_entries: int = 120) -> List[Dict[str, Any]]:
+    """Summarize test_steps for persistence (no large HTML/detail blobs)."""
+    out: List[Dict[str, Any]] = []
+    for step in test_steps[:max_entries]:
+        action = step.get("action", "")
+        agent = step.get("agent", "")
+        url = (step.get("url") or "")[:500]
+        entry: Dict[str, Any] = {"agent": agent, "action": action}
+        if url:
+            entry["url"] = url
+        if action == "plan":
+            detail = step.get("detail")
+            if isinstance(detail, str):
+                entry["detail_preview"] = detail[:240]
+        elif action in ("observe", "errors_detected"):
+            entry["has_detail"] = bool(step.get("detail") or step.get("console_errors"))
+        out.append(entry)
+    return out

--- a/agent/tools/screenshot.py
+++ b/agent/tools/screenshot.py
@@ -15,22 +15,28 @@ logger = logging.getLogger("bughunter.screenshot")
 SCREENSHOTS_DIR = os.path.join(os.path.dirname(__file__), "..", "screenshots")
 
 
-def capture(page, label: str) -> Dict[str, Any]:
+def capture(page, label: str, run_id: str = None) -> Dict[str, Any]:
     """
     Take a screenshot of the given Playwright page.
 
     Args:
         page: Playwright Page object
         label: Descriptive label for this screenshot
+        run_id: Optional test run ID; when provided, screenshots are saved under
+                screenshots/{run_id}/ instead of the root screenshots folder.
 
     Returns:
         dict with keys: label, base64, url (current page URL), timestamp, local_path
     """
-    os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
+    if run_id:
+        save_dir = os.path.join(SCREENSHOTS_DIR, str(run_id))
+    else:
+        save_dir = SCREENSHOTS_DIR
+    os.makedirs(save_dir, exist_ok=True)
 
     timestamp = int(time.time())
     filename = f"{label}_{timestamp}.png"
-    local_path = os.path.join(SCREENSHOTS_DIR, filename)
+    local_path = os.path.join(save_dir, filename)
 
     raw_bytes = page.screenshot(full_page=True)
     encoded = base64.b64encode(raw_bytes).decode("utf-8")

--- a/agent/tools/storage.py
+++ b/agent/tools/storage.py
@@ -9,6 +9,8 @@ import os
 from contextlib import contextmanager
 from typing import Any, Dict
 
+from tools.pipeline_log import build_pipeline_log
+
 import psycopg2
 import psycopg2.extras
 import psycopg2.pool
@@ -53,17 +55,43 @@ def save_run_to_db(run_id: str, status: str, results: Dict[str, Any]) -> bool:
             screenshots = results.get("screenshots", [])
             test_steps  = results.get("test_steps", [])
 
-            # Build a per-page record: url → first screenshot filename for that page
+            # Build a per-page record: url → first non-login-step screenshot for that page
+            # Also collect login step screenshots separately (label = "login_step_N")
             page_map: dict = {}
+            login_steps_by_page: dict = {}
             for shot in screenshots:
                 page_url = shot.get("url", "")
-                if page_url and page_url not in page_map:
+                label = shot.get("label", "")
+                if not page_url:
+                    continue
+                if label.startswith("login_step_"):
+                    login_steps_by_page.setdefault(page_url, []).append({
+                        "step": shot.get("login_step"),
+                        "action": shot.get("login_action", ""),
+                        "selector": shot.get("login_selector", ""),
+                        "screenshot_file": os.path.basename(shot["local_path"]) if shot.get("local_path") else None,
+                    })
+                elif page_url not in page_map:
                     local_path = shot.get("local_path", "")
                     page_map[page_url] = {
                         "url": page_url,
-                        "label": shot.get("label", ""),
+                        "label": label,
                         "screenshot_file": os.path.basename(local_path) if local_path else None,
                     }
+
+            # Collect per-page performance metrics from "observe" steps
+            metrics_by_page: dict = {}
+            for step in test_steps:
+                if step.get("action") != "observe":
+                    continue
+                u = step.get("url", "")
+                if not u:
+                    continue
+                metrics_by_page[u] = {
+                    "load_time_ms": step.get("load_time_ms", 0) or 0,
+                    "links_found": step.get("links_found", 0) or 0,
+                    "api_calls": step.get("api_calls", []) or [],
+                }
 
             # Summarise what each page had tested (from observer steps)
             steps_by_page: dict = {}
@@ -75,7 +103,8 @@ def save_run_to_db(run_id: str, status: str, results: Dict[str, Any]) -> bool:
                 if url not in steps_by_page:
                     steps_by_page[url] = []
                 if action in ("observe", "login_attempt", "login_flow_completed",
-                              "login_flow_failed", "errors_detected", "error"):
+                              "login_flow_failed", "smart_login_completed", "smart_login_partial",
+                              "smart_login_failed", "memory_login_completed", "errors_detected", "error"):
                     steps_by_page[url].append({
                         "action": action,
                         "detail": step.get("detail") or step.get("console_errors") or "",
@@ -83,16 +112,70 @@ def save_run_to_db(run_id: str, status: str, results: Dict[str, Any]) -> bool:
 
             pages_visited = []
             for page in page_map.values():
-                pages_visited.append({
+                metrics = metrics_by_page.get(page["url"], {})
+                api_calls = metrics.get("api_calls", [])
+                entry = {
                     **page,
                     "steps": steps_by_page.get(page["url"], []),
-                })
+                    "load_time_ms": metrics.get("load_time_ms", 0),
+                    "links_found": metrics.get("links_found", 0),
+                    "api_call_count": len(api_calls),
+                    "api_error_count": sum(1 for c in api_calls if c.get("status", 0) >= 400),
+                    "slowest_api_ms": max((c.get("duration_ms", 0) for c in api_calls), default=0),
+                }
+                login_steps = login_steps_by_page.get(page["url"], [])
+                if login_steps:
+                    entry["login_steps"] = login_steps
+                pages_visited.append(entry)
 
+            # Aggregate performance stats across all pages
+            all_load_times = [p["load_time_ms"] for p in pages_visited if p.get("load_time_ms")]
+            all_api_calls = [
+                c for p in pages_visited
+                for c in metrics_by_page.get(p["url"], {}).get("api_calls", [])
+            ]
+            avg_load_ms = round(sum(all_load_times) / len(all_load_times)) if all_load_times else 0
+            total_links = sum(p.get("links_found", 0) for p in pages_visited)
+            total_api = len(all_api_calls)
+            api_errors = sum(1 for c in all_api_calls if c.get("status", 0) >= 400)
+            slow_apis = [c for c in all_api_calls if c.get("duration_ms", 0) > 2000]
+
+            improvement_suggestions = []
+            if avg_load_ms > 3000:
+                improvement_suggestions.append(
+                    f"Average page load time is {avg_load_ms}ms — consider optimising server response times or enabling caching."
+                )
+            if api_errors > 0:
+                improvement_suggestions.append(
+                    f"{api_errors} API call(s) returned HTTP 4xx/5xx errors — review server error handling."
+                )
+            if slow_apis:
+                slowest = max(slow_apis, key=lambda c: c.get("duration_ms", 0))
+                improvement_suggestions.append(
+                    f"Slowest API call: {slowest['url']} took {slowest['duration_ms']}ms — consider optimising this endpoint."
+                )
+            if len(pages_visited) == 1 and total_links == 0:
+                improvement_suggestions.append(
+                    "Only one page was explored and no same-origin links were found — ensure navigation links are present and reachable."
+                )
+
+            strategic_plan = results.get("strategic_plan")
+            visited_urls = results.get("visited_urls")
+            dedupe_stats = results.get("dedupe_stats")
             summary = {
                 "total_bugs": len(results.get("bugs_found", [])),
                 "pages_explored": len(page_map),
                 "screenshots_taken": len(screenshots),
                 "pages_visited": pages_visited,
+                "strategic_plan": strategic_plan,
+                "visited_urls": visited_urls,
+                "dedupe_stats": dedupe_stats,
+                "pipeline_log": build_pipeline_log(test_steps),
+                "avg_load_time_ms": avg_load_ms,
+                "total_links_found": total_links,
+                "total_api_calls": total_api,
+                "api_error_count": api_errors,
+                "improvement_suggestions": improvement_suggestions,
             }
 
             cur.execute(

--- a/agent/tools/storage.py
+++ b/agent/tools/storage.py
@@ -50,12 +50,49 @@ def save_run_to_db(run_id: str, status: str, results: Dict[str, Any]) -> bool:
         with _get_conn() as conn:
             cur = conn.cursor()
 
+            screenshots = results.get("screenshots", [])
+            test_steps  = results.get("test_steps", [])
+
+            # Build a per-page record: url → first screenshot filename for that page
+            page_map: dict = {}
+            for shot in screenshots:
+                page_url = shot.get("url", "")
+                if page_url and page_url not in page_map:
+                    local_path = shot.get("local_path", "")
+                    page_map[page_url] = {
+                        "url": page_url,
+                        "label": shot.get("label", ""),
+                        "screenshot_file": os.path.basename(local_path) if local_path else None,
+                    }
+
+            # Summarise what each page had tested (from observer steps)
+            steps_by_page: dict = {}
+            for step in test_steps:
+                url = step.get("url", "")
+                action = step.get("action", "")
+                if not url:
+                    continue
+                if url not in steps_by_page:
+                    steps_by_page[url] = []
+                if action in ("observe", "login_attempt", "login_flow_completed",
+                              "login_flow_failed", "errors_detected", "error"):
+                    steps_by_page[url].append({
+                        "action": action,
+                        "detail": step.get("detail") or step.get("console_errors") or "",
+                    })
+
+            pages_visited = []
+            for page in page_map.values():
+                pages_visited.append({
+                    **page,
+                    "steps": steps_by_page.get(page["url"], []),
+                })
+
             summary = {
                 "total_bugs": len(results.get("bugs_found", [])),
-                "pages_explored": len(set(
-                    s.get("url", "") for s in results.get("test_steps", []) if s.get("url")
-                )),
-                "screenshots_taken": len(results.get("screenshots", [])),
+                "pages_explored": len(page_map),
+                "screenshots_taken": len(screenshots),
+                "pages_visited": pages_visited,
             }
 
             cur.execute(

--- a/agent/worker/runner.py
+++ b/agent/worker/runner.py
@@ -7,6 +7,7 @@ saves results to PostgreSQL and notifies the backend via HTTP.
 import json
 import logging
 import os
+import threading
 import time
 
 import httpx
@@ -28,6 +29,8 @@ logger = logging.getLogger("bughunter.runner")
 
 QUEUE_KEY = "bughunter:jobs"
 POLL_TIMEOUT = 5  # seconds to block-wait for a job
+HEARTBEAT_INTERVAL = 30  # seconds between heartbeats
+HEARTBEAT_TTL = 90  # seconds before a heartbeat is considered stale
 
 
 class JobRunner:
@@ -107,6 +110,13 @@ class JobRunner:
 
         self._publish(run_id, "agent_start", {"agent": "orchestrator", "message": "Pipeline starting…"})
 
+        # Start heartbeat thread for this run
+        heartbeat_stop = threading.Event()
+        heartbeat_thread = threading.Thread(
+            target=self._heartbeat_loop, args=(run_id, heartbeat_stop), daemon=True
+        )
+        heartbeat_thread.start()
+
         try:
             final_state = self.graph.invoke(initial_state)
             bug_count = len(final_state.get("bugs_found", []))
@@ -137,7 +147,26 @@ class JobRunner:
                 {**initial_state, "error": str(exc), "bugs_found": [], "report": []},
             )
         finally:
+            heartbeat_stop.set()
+            self._clear_heartbeat(run_id)
             clear_run_control(run_id)
+
+    def _heartbeat_loop(self, run_id: str, stop_event: threading.Event):
+        """Periodically set a Redis key to signal the run is still alive."""
+        key = f"bughunter:heartbeat:{run_id}"
+        while not stop_event.is_set():
+            try:
+                self.redis.setex(key, HEARTBEAT_TTL, int(time.time()))
+            except Exception as exc:
+                logger.debug(f"Heartbeat write failed for {run_id}: {exc}")
+            stop_event.wait(HEARTBEAT_INTERVAL)
+
+    def _clear_heartbeat(self, run_id: str):
+        """Remove the heartbeat key when a run finishes."""
+        try:
+            self.redis.delete(f"bughunter:heartbeat:{run_id}")
+        except Exception:
+            pass
 
     def _publish(self, run_id: str, event_type: str, data: dict):
         """Publish a pipeline progress event to Redis Pub/Sub."""

--- a/agent/worker/runner.py
+++ b/agent/worker/runner.py
@@ -51,6 +51,7 @@ class JobRunner:
         run_id = job.get("run_id")
         app_url = job.get("app_url")
         credentials = job.get("credentials")
+        test_config = job.get("test_config")
 
         if not run_id or not app_url:
             logger.error(f"Invalid job payload: {job}")
@@ -66,6 +67,7 @@ class JobRunner:
             "run_id": run_id,
             "url": app_url,
             "credentials": credentials,
+            "test_config": test_config,
             "current_page": None,
             "screenshots": [],
             "screenshot_paths": [],

--- a/agent/worker/runner.py
+++ b/agent/worker/runner.py
@@ -14,6 +14,8 @@ import redis
 
 from graph.graph import build_graph
 from graph.state import AgentState
+from tools.control import SIGNAL_STOP, check_run_control, clear_run_control
+from tools.memory import extract_memory_updates, load_memory, save_memory
 from tools.storage import save_run_to_db
 
 logger = logging.getLogger("bughunter.runner")
@@ -49,6 +51,7 @@ class JobRunner:
             return
 
         run_id = job.get("run_id")
+        app_id = job.get("app_id")
         app_url = job.get("app_url")
         credentials = job.get("credentials")
         test_config = job.get("test_config")
@@ -57,7 +60,12 @@ class JobRunner:
             logger.error(f"Invalid job payload: {job}")
             return
 
-        logger.info(f"Processing job run_id={run_id} url={app_url}")
+        logger.info(f"Processing job run_id={run_id} app_id={app_id} url={app_url}")
+
+        # Load per-app memory (returns {} on first run or if no app_id)
+        app_memory = load_memory(app_id) if app_id else {}
+        if app_memory:
+            logger.info(f"Loaded memory for app {app_id}: {app_memory.get('total_runs', 0)} prior run(s)")
 
         # Mark run as running
         self._update_run_status(run_id, "running")
@@ -77,6 +85,11 @@ class JobRunner:
             "error": None,
             "status": "running",
             "report": None,
+            "app_memory": app_memory,
+            "login_steps_for_memory": None,
+            "strategic_plan": None,
+            "visited_urls": None,
+            "dedupe_stats": None,
         }
 
         self._publish(run_id, "agent_start", {"agent": "orchestrator", "message": "Pipeline starting…"})
@@ -84,9 +97,22 @@ class JobRunner:
         try:
             final_state = self.graph.invoke(initial_state)
             bug_count = len(final_state.get("bugs_found", []))
-            save_run_to_db(run_id, "completed", final_state)
-            self._publish(run_id, "run_complete", {"total_bugs": bug_count, "message": f"Run completed — {bug_count} bug(s) found"})
-            logger.info(f"Job {run_id} completed. Bugs found: {bug_count}")
+
+            # Determine final status: the stop signal may have been set mid-run
+            was_stopped = check_run_control(run_id) == SIGNAL_STOP
+            final_status = "cancelled" if was_stopped else "completed"
+            save_run_to_db(run_id, final_status, final_state)
+
+            if final_status == "cancelled":
+                self._publish(run_id, "run_cancelled", {"message": f"Run cancelled — {bug_count} partial result(s) saved"})
+                logger.info(f"Job {run_id} cancelled. Partial bugs saved: {bug_count}")
+            else:
+                # Persist updated memory only after a full successful run
+                if app_id:
+                    updated_memory = extract_memory_updates(final_state, app_memory)
+                    save_memory(app_id, updated_memory)
+                self._publish(run_id, "run_complete", {"total_bugs": bug_count, "message": f"Run completed — {bug_count} bug(s) found"})
+                logger.info(f"Job {run_id} completed. Bugs found: {bug_count}")
 
         except Exception as exc:
             logger.error(f"Job {run_id} failed: {exc}", exc_info=True)
@@ -96,6 +122,8 @@ class JobRunner:
                 "failed",
                 {**initial_state, "error": str(exc), "bugs_found": [], "report": []},
             )
+        finally:
+            clear_run_control(run_id)
 
     def _publish(self, run_id: str, event_type: str, data: dict):
         """Publish a pipeline progress event to Redis Pub/Sub."""

--- a/agent/worker/runner.py
+++ b/agent/worker/runner.py
@@ -14,6 +14,13 @@ import redis
 
 from graph.graph import build_graph
 from graph.state import AgentState
+from tools.memory import (
+    extract_and_save_skills,
+    get_app_id_for_run,
+    load_agent_skills,
+    load_app_memory,
+    save_run_memory,
+)
 from tools.storage import save_run_to_db
 
 logger = logging.getLogger("bughunter.runner")
@@ -61,6 +68,18 @@ class JobRunner:
         # Mark run as running
         self._update_run_status(run_id, "running")
 
+        # Load memory & skills from previous runs on the same app
+        app_id = get_app_id_for_run(run_id)
+        memory = {}
+        skills = []
+        if app_id:
+            memory = load_app_memory(app_id)
+            skills = load_agent_skills(app_id, "all")
+            if memory:
+                logger.info(f"Loaded memory for app={app_id}: {len(memory.get('all_buggy_pages', []))} buggy pages, {len(memory.get('run_summaries', []))} past summaries")
+            if skills:
+                logger.info(f"Loaded {len(skills)} skill(s) for app={app_id}")
+
         # Build initial state
         initial_state: AgentState = {
             "run_id": run_id,
@@ -75,6 +94,9 @@ class JobRunner:
             "error": None,
             "status": "running",
             "report": None,
+            "memory": memory,
+            "skills": skills,
+            "app_id": app_id,
         }
 
         self._publish(run_id, "agent_start", {"agent": "orchestrator", "message": "Pipeline starting…"})
@@ -83,6 +105,12 @@ class JobRunner:
             final_state = self.graph.invoke(initial_state)
             bug_count = len(final_state.get("bugs_found", []))
             save_run_to_db(run_id, "completed", final_state)
+
+            # Save memory & extract skills for future runs
+            if app_id:
+                save_run_memory(run_id, app_id, final_state)
+                extract_and_save_skills(run_id, app_id, final_state, memory)
+
             self._publish(run_id, "run_complete", {"total_bugs": bug_count, "message": f"Run completed — {bug_count} bug(s) found"})
             logger.info(f"Job {run_id} completed. Bugs found: {bug_count}")
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,3 +19,8 @@ AGENT_API_SECRET=change-me-in-production
 
 # Redis auth password — must match REDIS_PASSWORD in docker-compose
 # REDIS_PASSWORD=change-me-in-production
+
+# Korn Ferry Talent app — SSO login credentials (Microsoft Entra IDP)
+# Used by start.sh to auto-register the app on startup
+KF_EMAIL=kf1sadmin@kfdbhdevoutlook.onmicrosoft.com
+KF_IDP_PASSWORD=

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -65,3 +65,62 @@ export async function login(req, res, next) {
 export async function me(req, res) {
   res.json({ user: req.user });
 }
+
+/** PATCH /api/auth/profile — update name, email, and/or password */
+export async function updateProfile(req, res, next) {
+  try {
+    const { name, email, current_password, new_password } = req.body;
+    const userId = req.user.id;
+
+    const result = await query('SELECT * FROM users WHERE id = $1', [userId]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    const u = result.rows[0];
+
+    const emailChanged = email !== undefined && String(email).trim().toLowerCase() !== String(u.email).toLowerCase();
+    const passwordChange = typeof new_password === 'string' && new_password.length > 0;
+
+    if (emailChanged || passwordChange) {
+      if (!current_password || typeof current_password !== 'string') {
+        return res.status(400).json({ error: 'Current password is required to change email or password' });
+      }
+      const ok = await bcrypt.compare(current_password, u.password_hash);
+      if (!ok) {
+        return res.status(401).json({ error: 'Current password is incorrect' });
+      }
+    }
+
+    if (emailChanged) {
+      const emailNorm = String(email).trim().toLowerCase();
+      const taken = await query('SELECT id FROM users WHERE LOWER(email) = $1 AND id <> $2', [emailNorm, userId]);
+      if (taken.rows.length > 0) {
+        return res.status(409).json({ error: 'Email already in use' });
+      }
+    }
+
+    let password_hash = u.password_hash;
+    if (passwordChange) {
+      if (new_password.length < 8) {
+        return res.status(400).json({ error: 'New password must be at least 8 characters' });
+      }
+      password_hash = await bcrypt.hash(new_password, SALT_ROUNDS);
+    }
+
+    const newName = name !== undefined ? String(name).trim() || null : u.name;
+    const newEmail = email !== undefined ? String(email).trim().toLowerCase() : u.email;
+
+    if (name !== undefined && !String(name).trim()) {
+      return res.status(400).json({ error: 'Name cannot be empty' });
+    }
+
+    const updated = await query(
+      'UPDATE users SET name = $1, email = $2, password_hash = $3 WHERE id = $4 RETURNING id, email, name',
+      [newName, newEmail, password_hash, userId]
+    );
+
+    res.json({ user: updated.rows[0] });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/controllers/bugs.controller.js
+++ b/backend/src/controllers/bugs.controller.js
@@ -4,12 +4,13 @@ import { query } from '../config/db.js';
 export async function listBugs(req, res, next) {
   try {
     // page and limit are already coerced integers from validateQuery middleware
-    const { run_id, severity, status, page = 1, limit = 20 } = req.query;
+    const { run_id, app_id, severity, status, page = 1, limit = 20 } = req.query;
     const offset = (page - 1) * limit;
 
     const baseWhere = `
       FROM bug_reports b
       JOIN test_runs r ON b.run_id = r.id
+      LEFT JOIN apps a ON b.app_id = a.id
       WHERE r.user_id = $1
     `;
     const params = [req.user.id];
@@ -17,12 +18,13 @@ export async function listBugs(req, res, next) {
     let filters = '';
 
     if (run_id)   { filters += ` AND b.run_id = $${idx++}`;   params.push(run_id); }
+    if (app_id)  { filters += ` AND b.app_id = $${idx++}`;   params.push(app_id); }
     if (severity) { filters += ` AND b.severity = $${idx++}`; params.push(severity); }
     if (status)   { filters += ` AND b.status = $${idx++}`;   params.push(status); }
 
     const countResult = await query(`SELECT COUNT(*) ${baseWhere}${filters}`, params);
 
-    const sql = `SELECT b.* ${baseWhere}${filters} ORDER BY b.created_at DESC LIMIT $${idx++} OFFSET $${idx++}`;
+    const sql = `SELECT b.*, a.name AS app_name ${baseWhere}${filters} ORDER BY b.created_at DESC LIMIT $${idx++} OFFSET $${idx++}`;
     params.push(limit, offset);
 
     const result = await query(sql, params);

--- a/backend/src/controllers/runs.controller.js
+++ b/backend/src/controllers/runs.controller.js
@@ -54,7 +54,7 @@ export async function listRuns(req, res, next) {
 /** POST /api/runs */
 export async function createRun(req, res, next) {
   try {
-    const { app_id } = req.body;
+    const { app_id, test_config } = req.body;
 
     // Verify app belongs to user
     const appResult = await query(
@@ -80,7 +80,7 @@ export async function createRun(req, res, next) {
     const plainCredentials = decrypt(app.credentials);
 
     // Enqueue job for the Python agent
-    await enqueueTestRun(run.id, app.url, plainCredentials);
+    await enqueueTestRun(run.id, app.url, plainCredentials, test_config || null);
 
     res.status(201).json({ run });
   } catch (err) {

--- a/backend/src/controllers/runs.controller.js
+++ b/backend/src/controllers/runs.controller.js
@@ -1,6 +1,10 @@
 import { query } from '../config/db.js';
 import { enqueueTestRun } from '../queue/testQueue.js';
 import { decrypt } from '../lib/crypto.js';
+import client from '../config/redis.js';
+
+const CONTROL_KEY = (runId) => `bughunter:control:${runId}`;
+const CONTROL_TTL = 3600; // seconds
 
 /** GET /api/runs */
 export async function listRuns(req, res, next) {
@@ -80,7 +84,7 @@ export async function createRun(req, res, next) {
     const plainCredentials = decrypt(app.credentials);
 
     // Enqueue job for the Python agent
-    await enqueueTestRun(run.id, app.url, plainCredentials, test_config || null);
+    await enqueueTestRun(run.id, app_id, app.url, plainCredentials, test_config || null);
 
     res.status(201).json({ run });
   } catch (err) {
@@ -124,7 +128,7 @@ export async function updateRun(req, res, next) {
        SET status    = $1,
            summary   = COALESCE($2, summary),
            error     = COALESCE($3, error),
-           completed_at = CASE WHEN $1 IN ('completed','failed') THEN NOW() ELSE completed_at END
+           completed_at = CASE WHEN $1::text IN ('completed','failed','cancelled') THEN NOW() ELSE completed_at END
        WHERE id = $4
        RETURNING id, status, summary, error, completed_at`,
       [status, summary ?? null, error ?? null, req.params.id]
@@ -134,6 +138,65 @@ export async function updateRun(req, res, next) {
       return res.status(404).json({ error: 'Run not found' });
     }
 
+    res.json({ run: result.rows[0] });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** POST /api/runs/:id/stop — send stop signal and mark run as cancelled */
+export async function stopRun(req, res, next) {
+  try {
+    const result = await query(
+      `UPDATE test_runs
+       SET status = 'cancelled', completed_at = NOW()
+       WHERE id = $1 AND user_id = $2 AND status IN ('pending','running','paused')
+       RETURNING id, status`,
+      [req.params.id, req.user.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Run not found or already finished' });
+    }
+    // Signal the agent worker to stop after its current page
+    await client.set(CONTROL_KEY(req.params.id), 'stop', { EX: CONTROL_TTL });
+    res.json({ run: result.rows[0] });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** POST /api/runs/:id/pause — send pause signal and mark run as paused */
+export async function pauseRun(req, res, next) {
+  try {
+    const result = await query(
+      `UPDATE test_runs SET status = 'paused'
+       WHERE id = $1 AND user_id = $2 AND status = 'running'
+       RETURNING id, status`,
+      [req.params.id, req.user.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Run not found or not currently running' });
+    }
+    await client.set(CONTROL_KEY(req.params.id), 'pause', { EX: CONTROL_TTL });
+    res.json({ run: result.rows[0] });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** POST /api/runs/:id/resume — clear pause signal and mark run as running */
+export async function resumeRun(req, res, next) {
+  try {
+    const result = await query(
+      `UPDATE test_runs SET status = 'running'
+       WHERE id = $1 AND user_id = $2 AND status = 'paused'
+       RETURNING id, status`,
+      [req.params.id, req.user.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Run not found or not paused' });
+    }
+    await client.del(CONTROL_KEY(req.params.id));
     res.json({ run: result.rows[0] });
   } catch (err) {
     next(err);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { createLogger, format, transports } from 'winston';
@@ -11,16 +12,26 @@ import appsRoutes from './routes/apps.routes.js';
 import runsRoutes from './routes/runs.routes.js';
 import bugsRoutes from './routes/bugs.routes.js';
 import apitestRoutes from './routes/apitest.routes.js';
+import { startReaper } from './jobs/staleRunReaper.js';
 
 // ── Logger ──────────────────────────────────────────────────────────────────
 export const logger = createLogger({
-  level: 'info',
+  level: process.env.LOG_LEVEL || 'info',
   format: format.combine(
     format.timestamp(),
-    format.colorize(),
-    format.printf(({ timestamp, level, message }) => `${timestamp} [${level}]: ${message}`)
+    format.json(),
   ),
-  transports: [new transports.Console()],
+  transports: [
+    new transports.Console({
+      format: format.combine(
+        format.colorize(),
+        format.printf(({ timestamp, level, message, ...meta }) => {
+          const extra = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
+          return `${timestamp} [${level}]: ${message}${extra}`;
+        }),
+      ),
+    }),
+  ],
 });
 
 // ── Startup assertions — fail fast on missing/weak secrets ──────────────────
@@ -48,14 +59,67 @@ app.use(cors({
 app.use(express.json({ limit: '5mb' }));
 app.use(express.urlencoded({ extended: true, limit: '5mb' }));
 
+// ── Global API rate limiter (100 req / 15 min per IP) ────────────────────────
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: parseInt(process.env.RATE_LIMIT_MAX || '100', 10),
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) => req.path === '/health',
+  message: { error: 'Too many requests, please try again later.' },
+});
+app.use('/api', apiLimiter);
+
+// ── Request logging ──────────────────────────────────────────────────────────
+app.use((req, res, next) => {
+  const start = Date.now();
+  res.on('finish', () => {
+    const duration = Date.now() - start;
+    const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warn' : 'info';
+    logger[level]('request', {
+      method: req.method,
+      path: req.originalUrl,
+      status: res.statusCode,
+      duration_ms: duration,
+      ip: req.ip,
+    });
+  });
+  next();
+});
+
 // ── Static screenshots (served from agent/screenshots/) ───────────────────────
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const screenshotsDir = join(__dirname, '../../agent/screenshots');
 app.use('/screenshots', express.static(screenshotsDir));
 
-// ── Health check ─────────────────────────────────────────────────────────────
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok', service: 'bughunter-api', timestamp: new Date().toISOString() });
+// ── Health check (deep — verifies DB + Redis) ──────────────────────────────
+app.get('/health', async (_req, res) => {
+  const checks = { db: 'ok', redis: 'ok' };
+  let status = 200;
+
+  try {
+    const { query: dbQuery } = await import('./config/db.js');
+    await dbQuery('SELECT 1');
+  } catch {
+    checks.db = 'error';
+    status = 503;
+  }
+
+  try {
+    const redisModule = await import('./config/redis.js');
+    await redisModule.default.ping();
+  } catch {
+    checks.redis = 'error';
+    status = 503;
+  }
+
+  res.status(status).json({
+    status: status === 200 ? 'ok' : 'degraded',
+    service: 'bughunter-api',
+    timestamp: new Date().toISOString(),
+    uptime_s: Math.floor(process.uptime()),
+    checks,
+  });
 });
 
 // ── Routes ────────────────────────────────────────────────────────────────────
@@ -79,7 +143,8 @@ app.use((err, _req, res, _next) => {
 // ── Start ─────────────────────────────────────────────────────────────────
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => {
-  logger.info(`🐛 BugHunter API running on http://localhost:${PORT}`);
+  logger.info(`BugHunter API running on http://localhost:${PORT}`);
+  startReaper();
 });
 
 export default app;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,8 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { createLogger, format, transports } from 'winston';
 
 import authRoutes from './routes/auth.routes.js';
@@ -45,6 +47,11 @@ app.use(cors({
 }));
 app.use(express.json({ limit: '5mb' }));
 app.use(express.urlencoded({ extended: true, limit: '5mb' }));
+
+// ── Static screenshots (served from agent/screenshots/) ───────────────────────
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const screenshotsDir = join(__dirname, '../../agent/screenshots');
+app.use('/screenshots', express.static(screenshotsDir));
 
 // ── Health check ─────────────────────────────────────────────────────────────
 app.get('/health', (_req, res) => {

--- a/backend/src/jobs/staleRunReaper.js
+++ b/backend/src/jobs/staleRunReaper.js
@@ -1,0 +1,71 @@
+/**
+ * Stale Run Reaper
+ * Periodically checks for runs stuck in "running" status whose agent heartbeat
+ * has expired, and marks them as "failed". This prevents ghost runs from
+ * appearing indefinitely in the UI when the agent process crashes mid-run.
+ */
+
+import { query } from '../config/db.js';
+import redisClient from '../config/redis.js';
+import { logger } from '../index.js';
+
+const REAP_INTERVAL_MS = 60_000; // check every 60 seconds
+const STALE_THRESHOLD_S = 90;    // must match agent HEARTBEAT_TTL
+
+let timer = null;
+
+async function reapStaleRuns() {
+  try {
+    // Find runs that have been "running" for a while
+    const result = await query(
+      `SELECT id FROM test_runs
+       WHERE status = 'running'
+         AND started_at < NOW() - INTERVAL '3 minutes'`
+    );
+
+    for (const row of result.rows) {
+      const runId = row.id;
+      const heartbeatKey = `bughunter:heartbeat:${runId}`;
+
+      try {
+        const hb = await redisClient.get(heartbeatKey);
+        if (hb === null) {
+          // No heartbeat at all — agent never started or already crashed
+          await markFailed(runId, 'Agent process stopped responding (no heartbeat)');
+        } else {
+          const age = Math.floor(Date.now() / 1000) - parseInt(hb, 10);
+          if (age > STALE_THRESHOLD_S) {
+            await markFailed(runId, `Agent heartbeat stale (${age}s since last beat)`);
+          }
+        }
+      } catch (err) {
+        logger.warn(`Reaper: failed to check heartbeat for run ${runId}: ${err.message}`);
+      }
+    }
+  } catch (err) {
+    logger.error(`Reaper: failed to query stale runs: ${err.message}`);
+  }
+}
+
+async function markFailed(runId, reason) {
+  logger.warn(`Reaper: marking run ${runId} as failed — ${reason}`);
+  await query(
+    `UPDATE test_runs SET status = 'failed', error = $2, completed_at = NOW()
+     WHERE id = $1 AND status = 'running'`,
+    [runId, reason]
+  );
+}
+
+export function startReaper() {
+  logger.info('Stale run reaper started');
+  timer = setInterval(reapStaleRuns, REAP_INTERVAL_MS);
+  // Run once immediately on startup
+  reapStaleRuns();
+}
+
+export function stopReaper() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/backend/src/queue/testQueue.js
+++ b/backend/src/queue/testQueue.js
@@ -23,12 +23,14 @@ const testQueue = new Queue(QUEUE_NAME, { connection });
  * @param {string} runId - UUID of the test run
  * @param {string} appUrl - URL of the app to test
  * @param {object|null} credentials - Plaintext login credentials (never ciphertext)
+ * @param {object|null} testConfig - Optional test configuration {max_pages, instructions, focus_areas}
  */
-export async function enqueueTestRun(runId, appUrl, credentials = null) {
+export async function enqueueTestRun(runId, appUrl, credentials = null, testConfig = null) {
   const payload = {
     run_id: runId,
     app_url: appUrl,
     credentials,
+    test_config: testConfig,
     enqueued_at: new Date().toISOString(),
   };
 

--- a/backend/src/queue/testQueue.js
+++ b/backend/src/queue/testQueue.js
@@ -21,13 +21,15 @@ const testQueue = new Queue(QUEUE_NAME, { connection });
  * and also adds a BullMQ job for observability and retry support.
  *
  * @param {string} runId - UUID of the test run
+ * @param {string} appId - UUID of the app (used by Python worker to load/save app memory)
  * @param {string} appUrl - URL of the app to test
  * @param {object|null} credentials - Plaintext login credentials (never ciphertext)
  * @param {object|null} testConfig - Optional test configuration {max_pages, instructions, focus_areas}
  */
-export async function enqueueTestRun(runId, appUrl, credentials = null, testConfig = null) {
+export async function enqueueTestRun(runId, appId, appUrl, credentials = null, testConfig = null) {
   const payload = {
     run_id: runId,
+    app_id: appId,
     app_url: appUrl,
     credentials,
     test_config: testConfig,

--- a/backend/src/routes/apps.routes.js
+++ b/backend/src/routes/apps.routes.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { authenticate } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
+import { query } from '../config/db.js';
 import {
   createApp,
   deleteApp,
@@ -36,5 +37,48 @@ router.post('/', validate(appSchema), createApp);
 router.get('/:id', getApp);
 router.put('/:id', validate(appSchema.partial()), updateApp);
 router.delete('/:id', deleteApp);
+
+/**
+ * GET /api/apps/:id/memory
+ * Returns the agent memory blob for an app (login steps, page scores, known bugs).
+ * Ownership is verified: the app must belong to the authenticated user.
+ */
+router.get('/:id/memory', async (req, res, next) => {
+  try {
+    const ownerCheck = await query(
+      'SELECT id FROM apps WHERE id = $1 AND user_id = $2',
+      [req.params.id, req.user.id]
+    );
+    if (ownerCheck.rows.length === 0) return res.status(404).json({ error: 'App not found' });
+
+    const result = await query(
+      'SELECT data, updated_at FROM app_memory WHERE app_id = $1',
+      [req.params.id]
+    );
+    if (result.rows.length === 0) return res.json({ data: null });
+    res.json({ data: result.rows[0].data, updated_at: result.rows[0].updated_at });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * DELETE /api/apps/:id/memory
+ * Clears the agent memory for an app so the next run starts fresh.
+ */
+router.delete('/:id/memory', async (req, res, next) => {
+  try {
+    const ownerCheck = await query(
+      'SELECT id FROM apps WHERE id = $1 AND user_id = $2',
+      [req.params.id, req.user.id]
+    );
+    if (ownerCheck.rows.length === 0) return res.status(404).json({ error: 'App not found' });
+
+    await query('DELETE FROM app_memory WHERE app_id = $1', [req.params.id]);
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import rateLimit from 'express-rate-limit';
 import { authenticate } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
-import { login, me, register } from '../controllers/auth.controller.js';
+import { login, me, register, updateProfile } from '../controllers/auth.controller.js';
 
 const router = Router();
 
@@ -26,8 +26,16 @@ const loginSchema = z.object({
   password: z.string().min(1),
 });
 
+const updateProfileSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  email: z.string().email().optional(),
+  current_password: z.string().optional(),
+  new_password: z.string().min(8).optional(),
+});
+
 router.post('/register', authLimiter, validate(registerSchema), register);
 router.post('/login', authLimiter, validate(loginSchema), login);
 router.get('/me', authenticate, me);
+router.patch('/profile', authenticate, validate(updateProfileSchema), updateProfile);
 
 export default router;

--- a/backend/src/routes/runs.routes.js
+++ b/backend/src/routes/runs.routes.js
@@ -8,6 +8,9 @@ import {
   deleteRun,
   getRun,
   listRuns,
+  pauseRun,
+  resumeRun,
+  stopRun,
   updateRun,
 } from '../controllers/runs.controller.js';
 import { query } from '../config/db.js';
@@ -28,21 +31,23 @@ const createRunSchema = z.object({
   app_id: z.string().uuid('Must be a valid app UUID'),
   notes: z.string().optional(),
   test_config: z.object({
-    max_pages:    z.number().int().min(1).max(20).optional(),
-    instructions: z.string().optional(),
-    focus_areas:  z.string().optional(),
+    max_pages:              z.number().int().min(1).max(20).optional(),
+    instructions:           z.string().optional(),
+    focus_areas:            z.string().optional(),
+    screenshot_login_steps: z.boolean().optional(),
+    detailed_report:        z.boolean().optional(),
   }).optional(),
 });
 
 const listRunsQuerySchema = z.object({
   app_id: z.string().uuid().optional(),
-  status: z.enum(['pending', 'running', 'completed', 'failed']).optional(),
+  status: z.enum(['pending', 'running', 'completed', 'failed', 'cancelled', 'paused']).optional(),
   page:  z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
 });
 
 const updateRunSchema = z.object({
-  status:  z.enum(['pending', 'running', 'completed', 'failed']),
+  status:  z.enum(['pending', 'running', 'completed', 'failed', 'cancelled', 'paused']),
   summary: z.record(z.unknown()).optional(),
   error:   z.string().optional(),
 });
@@ -112,6 +117,9 @@ router.get('/', validateQuery(listRunsQuerySchema), listRuns);
 router.post('/', validate(createRunSchema), createRun);
 router.get('/:id', getRun);
 router.delete('/:id', deleteRun);
+router.post('/:id/stop', stopRun);
+router.post('/:id/pause', pauseRun);
+router.post('/:id/resume', resumeRun);
 
 /**
  * POST /api/runs/:id/generate-tests

--- a/backend/src/routes/runs.routes.js
+++ b/backend/src/routes/runs.routes.js
@@ -27,6 +27,11 @@ const router = Router();
 const createRunSchema = z.object({
   app_id: z.string().uuid('Must be a valid app UUID'),
   notes: z.string().optional(),
+  test_config: z.object({
+    max_pages:    z.number().int().min(1).max(20).optional(),
+    instructions: z.string().optional(),
+    focus_areas:  z.string().optional(),
+  }).optional(),
 });
 
 const listRunsQuerySchema = z.object({

--- a/database/migrations/007_agent_memory.sql
+++ b/database/migrations/007_agent_memory.sql
@@ -1,0 +1,41 @@
+-- 007_agent_memory.sql
+-- Adds tables for agent self-improvement: memory (per-app run history)
+-- and skills (reusable learned patterns).
+
+-- Per-app run memory: summarized learnings from each completed run
+CREATE TABLE IF NOT EXISTS agent_memory (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    app_id UUID NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+    run_id UUID NOT NULL REFERENCES test_runs(id) ON DELETE CASCADE,
+    buggy_pages JSONB DEFAULT '[]',
+    effective_strategies JSONB DEFAULT '[]',
+    navigation_map JSONB DEFAULT '{}',
+    security_findings JSONB DEFAULT '[]',
+    run_summary TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_memory_app_id ON agent_memory(app_id);
+CREATE INDEX IF NOT EXISTS idx_agent_memory_created_at ON agent_memory(created_at DESC);
+
+-- Reusable skills: learned patterns (app-specific or global)
+CREATE TABLE IF NOT EXISTS agent_skills (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    app_id UUID REFERENCES apps(id) ON DELETE CASCADE,  -- NULL = global skill
+    agent_type VARCHAR(50) NOT NULL,
+    skill_type VARCHAR(50) NOT NULL,
+    description TEXT NOT NULL,
+    skill_data JSONB NOT NULL DEFAULT '{}',
+    confidence FLOAT DEFAULT 0.5,
+    times_used INT DEFAULT 0,
+    times_effective INT DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_skills_app_id ON agent_skills(app_id);
+CREATE INDEX IF NOT EXISTS idx_agent_skills_agent_type ON agent_skills(agent_type);
+CREATE INDEX IF NOT EXISTS idx_agent_skills_global ON agent_skills(app_id) WHERE app_id IS NULL;
+
+-- Track migration
+INSERT INTO schema_migrations (version) VALUES ('007') ON CONFLICT DO NOTHING;

--- a/database/migrations/007_app_memory.sql
+++ b/database/migrations/007_app_memory.sql
@@ -1,0 +1,20 @@
+-- Migration 007: App-level persistent memory for smarter consecutive test runs.
+-- One row per app stores a JSONB blob with login steps, page scores, and known bugs.
+
+BEGIN;
+
+CREATE TABLE app_memory (
+  id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  app_id     UUID NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  data       JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Enforce exactly one memory record per app
+CREATE UNIQUE INDEX idx_app_memory_app_id ON app_memory (app_id);
+
+INSERT INTO schema_migrations (version) VALUES ('007_app_memory')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/database/migrations/008_run_status_enum.sql
+++ b/database/migrations/008_run_status_enum.sql
@@ -1,0 +1,11 @@
+-- Migration 008: Add 'paused' and 'cancelled' to run_status enum
+-- The stop/pause feature requires these values but they were missing from the original enum.
+
+BEGIN;
+
+ALTER TYPE run_status ADD VALUE IF NOT EXISTS 'cancelled';
+ALTER TYPE run_status ADD VALUE IF NOT EXISTS 'paused';
+
+INSERT INTO schema_migrations (version) VALUES ('008') ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -139,6 +139,8 @@ If Smart Login fails, switch to **SSO / Multi-Step** and define each step explic
 | **Focus areas** | Areas to prioritize | `authentication, forms, navigation` |
 | **Pages to explore** | Slider 1–20 (default 5) | `10` for deeper coverage |
 | **Notes** | Run-level notes for your records | `Post-deployment smoke test` |
+| **Capture login screenshots** | Toggle — screenshot after each auto-login step | Default: on |
+| **Detailed AI report** | Toggle — AI enriches each bug with structured report. Off = quick mode (bugs logged instantly, no LLM enrichment) | Default: **off** |
 
 5. Click **Start Test Run**
 
@@ -146,23 +148,29 @@ You are redirected to the Bug Reports page for that run where you can watch resu
 
 > **Tip:** More pages = deeper coverage but longer run time. For a quick smoke test use 3–5 pages; for thorough coverage use 10–15.
 
+> **Quick mode** (Detailed AI report off) is faster — bugs are logged without LLM enrichment. Enable for thorough analysis when you want structured steps-to-reproduce.
+
+> **Note:** You can also start a run directly from the **Applications** page — click the **Run** button on any app row to open the modal pre-configured for that app.
+
 ---
 
 ## Step 4 — What the Agent Does
 
-Once a run starts, the LangGraph agent pipeline executes automatically:
+Once a run starts, the LangGraph agent pipeline executes automatically (fixed order, no branching):
 
 ```
-OrchestratorAgent  →  plans which pages and flows to test
+OrchestratorAgent  →  LLM JSON plan (pages, journeys, focus) — drives Explorer priorities
        ↓
-ExplorerAgent      →  navigates the site using Playwright, takes screenshots
+ExplorerAgent      →  Playwright navigation, screenshots, console/network errors; records visited URLs
        ↓
-ValidatorAgent     →  analyzes screenshots with LLM vision for functional bugs
+ValidatorAgent     →  LLM review of `observe` / `errors_detected` steps for functional issues
        ↓
-SecurityAgent      →  runs active tests: XSS payloads, SQL injection, auth bypass, secret scanning
+SecurityAgent      →  XSS / SQLi / secret patterns on the seed URL + visited URLs (capped)
        ↓
-ReporterAgent      →  structures all findings into bug reports saved to the database
+ReporterAgent      →  deduplicates raw findings, then LLM structured bug reports to PostgreSQL
 ```
+
+The run’s **summary** JSON in PostgreSQL can include `strategic_plan`, `visited_urls`, `dedupe_stats`, and `pipeline_log` for debugging and tuning.
 
 **Run status values:**
 
@@ -172,6 +180,24 @@ ReporterAgent      →  structures all findings into bug reports saved to the da
 | `running` | Agent is actively exploring and testing |
 | `completed` | All agents finished; bug reports are ready |
 | `failed` | An error occurred — check `logs/agent.log` |
+| `paused` | Run is suspended — agent is waiting for resume signal |
+| `cancelled` | Run was stopped mid-run — partial results saved |
+
+---
+
+## Stopping and Pausing a Run
+
+You can control an active run from the run detail page or the Test Runs list.
+
+| Control | Where available | Effect |
+|---------|----------------|--------|
+| **Stop** | Run detail + Test Runs list | Immediately signals the agent to stop. The run is marked `cancelled` and any bugs found so far are saved. |
+| **Pause** | Run detail only (when `running`) | Signals the agent to pause after the current page. The run is marked `paused`. |
+| **Resume** | Run detail only (when `paused`) | Clears the pause signal; run continues from where it left off. |
+
+**How it works:** The backend sets a Redis key (`bughunter:control:{run_id}`). The agent checks this key at the start of each page and before each pipeline stage. On stop, partial bug results are saved to the database.
+
+> **Note:** Stopping a run does not discard findings — bugs found up to the stop point are preserved and visible on the run detail page.
 
 ---
 
@@ -181,13 +207,19 @@ After the run completes:
 
 1. Go to **Test Runs** in the sidebar
 2. Click on the completed run
-3. Each bug report shows:
+3. On the run detail page you can use:
+   - **Agent pipeline** — live stepper for Orchestrator → Explorer → Validator → Security → Reporter
+   - **Live Activity** — flat SSE event stream (and retained log after completion)
+   - **Agent logs** — the same events grouped by agent with filters
+4. Each bug report shows:
    - **Title** — brief description of the issue
    - **Severity** — `critical`, `high`, `medium`, `low`, or `info`
    - **Status** — `open`, `confirmed`, or `false_positive`
    - **Page URL** — the exact URL where the bug was found
    - **Description** — detailed LLM analysis of the issue
    - **Screenshot** — visual evidence captured by Playwright
+
+To read static descriptions of each agent and the pipeline order, open **AI Agents** in the sidebar (`/agents`).
 
 ---
 
@@ -256,6 +288,7 @@ The image may still be pulling on first run. Wait 60 seconds and retry.
 - **DVWA Low difficulty** produces the most findings as security controls are disabled
 - **Juice Shop** has over 100 challenges — each run will likely surface different issues
 - **Enterprise apps**: register once per user type (SSO user / non-SSO user) with their respective credentials
+- **Quick mode** is the default — enable "Detailed AI report" only when you need structured steps-to-reproduce per bug (it adds LLM enrichment time)
 
 ---
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -1,6 +1,6 @@
 # BugHunter.AI — Testing Guide
 
-This guide walks through adding a sample test site to BugHunter.AI and running an AI-powered bug scan against it. The two sample sites included in the Docker Compose setup are used as examples.
+This guide walks through adding an application to BugHunter.AI and running an AI-powered bug scan against it.
 
 ---
 
@@ -12,6 +12,8 @@ This guide walks through adding a sample test site to BugHunter.AI and running a
 | **DVWA** | http://localhost:8080 | admin / password | Classic PHP app with configurable vulnerability levels |
 
 Both start automatically when you run `./start.sh` (Linux/macOS) or `./start.ps1` (Windows).
+
+All three sample apps — including any app configured in `backend/.env` (e.g. Korn Ferry) — are **auto-registered** on startup. No manual registration needed.
 
 ---
 
@@ -42,8 +44,8 @@ Navigate to **Application Inventory** in the left sidebar and click **Add Applic
 |-------|-------|
 | **Application Name** | `OWASP Juice Shop` |
 | **URL** | `http://localhost:3000` |
-| **Authentication** | Simple Login |
-| **Username / Email** | `admin@juice-sh.op` |
+| **Authentication** | Smart Login (Auto) |
+| **Email** | `admin@juice-sh.op` |
 | **Password** | `admin123` |
 
 Click **Save Application**.
@@ -52,14 +54,12 @@ Click **Save Application**.
 
 ### Adding DVWA
 
-DVWA uses a standard HTML login form. Use **Simple Login**:
-
 | Field | Value |
 |-------|-------|
 | **Application Name** | `DVWA` |
 | **URL** | `http://localhost:8080/login.php` |
-| **Authentication** | Simple Login |
-| **Username / Email** | `admin` |
+| **Authentication** | Smart Login (Auto) |
+| **Email** | `admin` |
 | **Password** | `password` |
 
 Click **Save Application**.
@@ -68,26 +68,61 @@ Click **Save Application**.
 
 ---
 
-### Authentication Modes Explained
+### Adding an Enterprise App (e.g. Korn Ferry Talent)
 
-BugHunter.AI supports three authentication modes when registering an app:
+For apps with SSO or email-first login, use **Smart Login (Auto)** — just provide the email and password. The agent figures out the flow automatically.
+
+| Field | Value |
+|-------|-------|
+| **Application Name** | `Korn Ferry Talent (SSO)` |
+| **URL** | `https://home.kornferrytalent-dev.com/login` |
+| **Authentication** | Smart Login (Auto) |
+| **Email** | `user@company.com` |
+| **Password** | Your IDP password |
+
+The agent will handle: email-first page → SSO redirect to Microsoft/Okta IDP → password entry → redirect back to the app.
+
+For **non-SSO users** on the same app, register a second entry with the non-SSO user's email and app password — the agent adapts automatically based on what it sees.
+
+To auto-register an enterprise app on every `./start.sh`, add to `backend/.env`:
+```env
+KF_EMAIL=user@company.com
+KF_IDP_PASSWORD=your-password
+```
+
+---
+
+### Authentication Modes Explained
 
 | Mode | When to use |
 |------|-------------|
 | **None** | Public sites that require no login |
-| **Simple Login** | Standard username + password forms — the agent fills them automatically |
-| **SSO / Multi-Step** | Complex flows (MFA, SSO redirects, token entry) — you define each Playwright step manually |
+| **Smart Login (Auto)** | Any login flow — the agent uses the LLM to navigate automatically. Handles standard forms, email-first pages, SSO/IDP redirects (Microsoft, Okta, Google), and more |
+| **SSO / Multi-Step** | Manual override — you define each Playwright step explicitly. Use this only if Smart Login fails (e.g. login inside an iframe) |
 
-#### SSO / Multi-Step Flow Example (Juice Shop)
+#### How Smart Login Works
 
-If Simple Login doesn't work for your target, switch to **SSO / Multi-Step** and define the steps manually:
+When given just an email and password, the agent runs an iterative loop (up to 12 steps):
+
+1. Reads the current page HTML
+2. Asks the LLM: *"What is the single next action to log in?"*
+3. Executes the action (fill, click, wait for redirect, etc.)
+4. Repeats until the URL leaves all login/auth pages or the LLM signals done
+
+The real password is **never sent to the LLM** — a placeholder `__PASSWORD__` is used in prompts and substituted locally before browser execution.
+
+#### SSO / Multi-Step (Manual Override)
+
+If Smart Login fails, switch to **SSO / Multi-Step** and define each step explicitly:
 
 | Step | Action | Selector | Value |
 |------|--------|----------|-------|
-| 1 | Fill input | `input[type="email"]` | `admin@juice-sh.op` |
-| 2 | Fill input | `input[type="password"]` | `admin123` |
-| 3 | Click element | `button[type="submit"]` | — |
-| 4 | Wait for redirect | — | timeout: 5000 |
+| 1 | Fill input | `input[type="email"]` | `user@example.com` |
+| 2 | Click element | `button[type="submit"]` | — |
+| 3 | Wait for redirect | — | timeout: 15000 |
+| 4 | Fill input | `input[type="password"]` | `password` |
+| 5 | Click element | `button[type="submit"]` | — |
+| 6 | Wait for redirect | — | timeout: 20000 |
 
 ---
 
@@ -95,14 +130,21 @@ If Simple Login doesn't work for your target, switch to **SSO / Multi-Step** and
 
 1. Click **Test Runs** in the left sidebar
 2. Click **New Run** (or the **Start New Test Run** button)
-3. Select the application from the dropdown — e.g. `OWASP Juice Shop — http://localhost:3000`
-4. Optionally add notes to guide the agent, for example:
-   - `Focus on the shopping cart and checkout flow`
-   - `Test XSS in the search bar and product reviews`
-   - `Check for authentication bypass on admin routes`
+3. Select the application from the dropdown
+4. Configure the test (all fields optional):
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **What to test** | Specific instructions for the agent | `Test the client listing page — search, filters, and pagination` |
+| **Focus areas** | Areas to prioritize | `authentication, forms, navigation` |
+| **Pages to explore** | Slider 1–20 (default 5) | `10` for deeper coverage |
+| **Notes** | Run-level notes for your records | `Post-deployment smoke test` |
+
 5. Click **Start Test Run**
 
 You are redirected to the Bug Reports page for that run where you can watch results appear in real time.
+
+> **Tip:** More pages = deeper coverage but longer run time. For a quick smoke test use 3–5 pages; for thorough coverage use 10–15.
 
 ---
 
@@ -181,9 +223,9 @@ tail -f logs/agent.log
 Ensure the Python worker started successfully — look for `Job runner started` in the log.
 
 ### Agent cannot log in to the site
-- Verify the site is accessible at its URL in your browser
-- Try switching to **SSO / Multi-Step** auth and define each login step explicitly with exact CSS selectors
-- Use browser DevTools (F12 → Inspector) to find the correct selectors for input fields
+- Verify the site is accessible at its URL in your browser and credentials are correct
+- Check `logs/agent.log` for `Smart login step N:` lines to see where it stalled
+- If the login page renders inside an **iframe**, Smart Login may not work — switch to **SSO / Multi-Step** and define each step with explicit CSS selectors (use browser DevTools F12 → Inspector to find them)
 
 ### DVWA shows a blank page or database error
 Run the DVWA setup first:
@@ -198,18 +240,22 @@ docker logs bughunter-juice-shop
 The image may still be pulling on first run. Wait 60 seconds and retry.
 
 ### No bugs found
-- The agent explores up to 5 pages per run by default; complex apps may need multiple runs targeting different flows
-- Add specific notes when creating the run to focus the agent on known-vulnerable areas
+- Increase **Pages to explore** (slider in New Run modal) — default is 5
+- Use the **What to test** field to direct the agent to specific flows or pages
+- Run multiple times targeting different areas — each run is independent
 - Check `logs/agent.log` for the full exploration trace
 
 ---
 
 ## Tips for Better Results
 
-- **Use notes** when starting a run to direct the agent: `"Focus on the login form and user registration flow"`
+- **Use "What to test"** to direct the agent: `"Test the client listing — search, filter, and pagination"`
+- **Use "Focus areas"** for targeted scanning: `"authentication, forms, data display"`
+- **Increase pages** for deeper coverage — set to 10–15 for production apps
 - **Run multiple times** targeting different parts of the app — each run is independent
 - **DVWA Low difficulty** produces the most findings as security controls are disabled
 - **Juice Shop** has over 100 challenges — each run will likely surface different issues
+- **Enterprise apps**: register once per user type (SSO user / non-SSO user) with their respective credentials
 
 ---
 
@@ -224,4 +270,18 @@ DVWA              →  http://localhost:8080
   Username: admin
   Password: password
   Setup:    http://localhost:8080/setup.php  (run once after first launch)
+
+Enterprise apps   →  set KF_EMAIL and KF_IDP_PASSWORD in backend/.env
+                     auto-registered on ./start.sh
 ```
+
+## Authentication Mode Quick Reference
+
+| Scenario | Mode to use |
+|----------|-------------|
+| Public app, no login | None |
+| Standard login form (email + password on one page) | Smart Login (Auto) |
+| Email-first login (password on second page) | Smart Login (Auto) |
+| SSO / IDP redirect (Microsoft, Okta, Google) | Smart Login (Auto) |
+| Login inside an iframe | SSO / Multi-Step (manual) |
+| MFA / OTP required | SSO / Multi-Step (manual) |

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -159,15 +159,15 @@ You are redirected to the Bug Reports page for that run where you can watch resu
 Once a run starts, the LangGraph agent pipeline executes automatically (fixed order, no branching):
 
 ```
-OrchestratorAgent  →  LLM JSON plan (pages, journeys, focus) — drives Explorer priorities
+OrchestratorAgent  →  LLM JSON plan (pages, journeys, focus) — drives Explorer priorities; uses app memory + skills
        ↓
-ExplorerAgent      →  Playwright navigation, screenshots, console/network errors; records visited URLs
+ExplorerAgent      →  Playwright navigation, screenshots, console/network errors; form fuzzing, perf checks, a11y audits; records visited URLs
        ↓
-ValidatorAgent     →  LLM review of `observe` / `errors_detected` steps for functional issues
+ValidatorAgent     →  LLM review of `observe` / `errors_detected` steps + multimodal vision analysis of screenshots; regression detection
        ↓
-SecurityAgent      →  XSS / SQLi / secret patterns on the seed URL + visited URLs (capped)
+SecurityAgent      →  XSS / SQLi / secret patterns + HTTP header, cookie, CSRF checks; adaptive payloads from memory
        ↓
-ReporterAgent      →  deduplicates raw findings, then LLM structured bug reports to PostgreSQL
+ReporterAgent      →  semantic + fingerprint deduplication, then LLM structured bug reports to PostgreSQL
 ```
 
 The run’s **summary** JSON in PostgreSQL can include `strategic_plan`, `visited_urls`, `dedupe_stats`, and `pipeline_log` for debugging and tuning.
@@ -284,11 +284,13 @@ The image may still be pulling on first run. Wait 60 seconds and retry.
 - **Use "What to test"** to direct the agent: `"Test the client listing — search, filter, and pagination"`
 - **Use "Focus areas"** for targeted scanning: `"authentication, forms, data display"`
 - **Increase pages** for deeper coverage — set to 10–15 for production apps
-- **Run multiple times** targeting different parts of the app — each run is independent
+- **Run multiple times** targeting different parts of the app — each run is independent and builds on memory from previous runs
 - **DVWA Low difficulty** produces the most findings as security controls are disabled
 - **Juice Shop** has over 100 challenges — each run will likely surface different issues
 - **Enterprise apps**: register once per user type (SSO user / non-SSO user) with their respective credentials
 - **Quick mode** is the default — enable "Detailed AI report" only when you need structured steps-to-reproduce per bug (it adds LLM enrichment time)
+- **Self-improvement:** Each run builds memory — known bugs, login steps, page priority scores, and effective security payloads are carried over to the next run. Consecutive runs on the same app get progressively smarter.
+- **Clear memory** if you want a fresh start: use `DELETE /api/apps/:id/memory` or the memory management UI
 
 ---
 

--- a/documents/TECHNICAL_SPEC.md
+++ b/documents/TECHNICAL_SPEC.md
@@ -1,6 +1,6 @@
 # BugHunter.AI — Technical Specification
 
-> Version: 1.0 | Date: 2026-03-26 | Codebase: `bughunter-ai`
+> Version: 1.1 | Date: 2026-03-29 | Codebase: `bughunter-ai`
 
 ---
 
@@ -259,10 +259,15 @@ CREATE INDEX idx_apps_user_id ON apps(user_id);
 | updated_at | TIMESTAMPTZ | Updated on PATCH |
 
 **Credentials JSONB Structure (decrypted):**
+
+*Smart Login (Auto-detect)* — just email and password; the agent figures out the flow:
+```json
+{ "username": "user@example.com", "password": "plaintext-password" }
+```
+
+*SSO / Multi-Step (manual override)* — explicit Playwright step sequence:
 ```json
 {
-  "username": "user@example.com",
-  "password": "plaintext-password",
   "login_flow": [
     { "action": "fill",                "selector": "input[type='email']",    "value": "user@example.com" },
     { "action": "click",               "selector": "button[type='submit']"                               },
@@ -553,13 +558,23 @@ Response `200`:
 
 Request:
 ```json
-{ "app_id": "uuid", "notes": "Optional notes" }
+{
+  "app_id": "uuid",
+  "notes": "Optional notes",
+  "test_config": {
+    "max_pages": 10,
+    "instructions": "Test the client listing page — search, filters, and pagination",
+    "focus_areas": "authentication, forms, navigation"
+  }
+}
 ```
+
+`test_config` is optional. All sub-fields are optional. Defaults: `max_pages=5`, empty instructions/focus_areas.
 
 Flow:
 1. Insert `test_runs` row with `status = 'pending'`
 2. Decrypt app credentials
-3. `RPUSH bughunter:jobs` (raw Redis list) + BullMQ `queue.add()`
+3. `RPUSH bughunter:jobs` (raw Redis list) + BullMQ `queue.add()` — both include `test_config`
 4. Return created run
 
 Response `201`: `{ "run": { "id": "uuid", "status": "pending", ... } }`
@@ -687,7 +702,7 @@ decrypt(ciphertext) // ciphertext string → JS object
 }
 ```
 
-**`enqueueTestRun(runId, appUrl, credentials)`** does two things:
+**`enqueueTestRun(runId, appUrl, credentials, testConfig)`** does two things:
 1. `RPUSH bughunter:jobs <json>` — consumed by Python via BLPOP
 2. `queue.add('run', payload, options)` — BullMQ for monitoring/retries
 
@@ -794,8 +809,8 @@ Navigation links:
 - Lists all registered apps with URL, creation date
 - **Create/Edit modal** with three credential modes:
   1. **None** — no credentials
-  2. **Simple** — username + password fields
-  3. **SSO / Multi-Step** — `LoginFlowBuilder` component
+  2. **Smart Login (Auto)** — email + password; agent drives login via LLM
+  3. **SSO / Multi-Step** — `LoginFlowBuilder` component (manual override)
 - `LoginFlowBuilder` sub-component: dynamically add/remove/reorder login steps; each step has `action`, `selector`, `value`, `timeout` fields
 - Delete app with confirmation
 
@@ -819,7 +834,12 @@ Navigation links:
 - Modal overlay
 - Loads app list on mount
 - Select app from dropdown
-- Calls `POST /api/runs` on submit
+- **Test Configuration section:**
+  - *What to test* — free-text instructions passed to the agent (e.g. `"Test client listing page — search, filters, pagination"`)
+  - *Focus areas* — comma-separated areas to prioritize (e.g. `"authentication, forms"`)
+  - *Pages to explore* — range slider 1–20 (default 5)
+- Optional *Notes* field for run-level record-keeping
+- Sends `test_config` object in `POST /api/runs` body
 - On success, redirects user to `/runs/:newRunId`
 
 ---
@@ -888,8 +908,10 @@ Temperature is fixed at 0.2 for consistent, deterministic LLM outputs.
 
 ```python
 class AgentState(TypedDict):
+    run_id: Optional[str]              # UUID of the test run (for SSE publishing)
     url: str                           # Target app URL
     credentials: Optional[Dict]        # Decrypted credentials from backend
+    test_config: Optional[Dict]        # {max_pages, instructions, focus_areas}
     current_page: Optional[str]        # Last visited URL
     screenshots: List[Dict]            # {label, base64, url, timestamp, local_path}
     screenshot_paths: List[str]        # Paths (after base64 stripped)
@@ -899,6 +921,15 @@ class AgentState(TypedDict):
     error: Optional[str]               # Error message if pipeline fails
     status: str                        # pending | running | completed | failed
     report: Optional[List[Dict]]       # Final structured bug reports
+```
+
+**`test_config` shape:**
+```python
+{
+    "max_pages": 10,           # Override AGENT_MAX_PAGES for this run
+    "instructions": "...",     # Free-text guidance for Orchestrator + Explorer
+    "focus_areas": "...",      # Comma-separated areas to prioritise
+}
 ```
 
 ---
@@ -948,15 +979,18 @@ def explore_node(state: AgentState) -> AgentState:
 
 #### OrchestratorAgent (`agents/orchestrator.py`)
 
-**Input:** `url`, `credentials`
+**Input:** `url`, `credentials`, `test_config`
 
 **Process:**
 1. Builds auth context description from credentials shape:
    - No credentials → "No authentication required"
-   - Simple credentials → "Simple username/password at `url`"
-   - Login flow → "Multi-step SSO/IDP flow"
-2. Calls `get_llm().invoke(prompt)` with URL and auth context
-3. LLM returns testing strategy: pages to test, user journeys, focus areas, notes
+   - `{username, password}` → "Smart auto-login with email + password"
+   - `{login_flow}` → "Multi-step SSO/IDP flow (N steps)"
+2. Incorporates `test_config` into the planning prompt:
+   - `instructions` → appended as "User instructions: ..."
+   - `focus_areas` → appended as "Focus areas: ..."
+   - `max_pages` → appended as "Explorer will visit up to N page(s)"
+3. Calls `get_llm().invoke(prompt)` and receives a structured test strategy
 
 **Output mutations:**
 - `test_steps`: Appended with `{ "action": "plan", "result": <llm_response> }`
@@ -966,28 +1000,41 @@ def explore_node(state: AgentState) -> AgentState:
 
 #### ExplorerAgent (`agents/explorer.py`)
 
-**Input:** `url`, `credentials`, `test_steps` (plan)
+**Input:** `url`, `credentials`, `test_config`, `test_steps` (plan)
 
 **Process:**
 1. Launches headless Chromium (1280×800 viewport)
-2. If credentials provided:
-   - **Multi-step flow** (`credentials.login_flow`): Execute each step in sequence (fill, click, wait_for_navigation, wait_for_selector, wait). Dismiss overlays before each step. Retry with `force=True` on overlay-blocked clicks.
-   - **Simple credentials**: Auto-fill email/username + password fields, click submit.
-3. Navigate up to `AGENT_MAX_PAGES` pages within the same domain
-4. For each page:
+2. Reads `test_config.max_pages` (falls back to `AGENT_MAX_PAGES` env var, default 5)
+3. If credentials provided, selects login strategy:
+   - **Option A — SSO / Multi-Step** (`credentials.login_flow`): Execute each pre-configured step in sequence. Dismiss overlays before each step. Retry with `force=True` on overlay-blocked clicks.
+   - **Option B — Smart Login (Auto)** (`credentials.username` + `credentials.password`): LLM-driven iterative login loop (see below).
+4. Navigate up to `max_pages` pages within the same domain
+5. For each page:
    - Capture full-page screenshot
+   - Ask LLM what to test (incorporating `test_config.instructions` and `test_config.focus_areas`)
    - Log console errors and network failures
    - Collect all links for further exploration
-5. Close browser
+6. Close browser
 
-**Input selectors tried for simple login:**
-- Email: `input[type='email'], input[name='username'], input[name='email']`
-- Password: `input[type='password']`
-- Submit: `button[type='submit'], input[type='submit'], button:has-text('Login'), button:has-text('Sign in')`
+**Smart Login loop (Option B):**
+
+Replaces the old dumb single-attempt login. Runs up to 12 iterations:
+1. Dismiss overlays, read current page HTML
+2. If URL is no longer a login/auth page (after first step) → success
+3. Build prompt with current HTML + email (never password) using `__PASSWORD__` placeholder
+4. LLM returns one action: `{action, selector, value, done}`
+5. Substitute `__PASSWORD__` → real password locally before execution
+6. Execute action (fill / click / wait_for_navigation / wait_for_selector)
+7. Repeat; stop when LLM sets `done=true`, URL escapes auth pages, or 12 iterations reached
+
+The real password is **never sent to the LLM**. Works for:
+- Standard single-page login forms
+- Email-first pages (password appears on second page)
+- SSO/IDP redirects (Microsoft Entra, Okta, Google)
 
 **Output mutations:**
 - `screenshots`: Array of `{ label, base64, url, timestamp, local_path }`
-- `test_steps`: Array of navigation steps and error observations
+- `test_steps`: Navigation steps, per-iteration smart login records, error observations
 - `current_page`: Last URL visited
 
 ---
@@ -1122,8 +1169,10 @@ class JobRunner:
 
     def _build_state(self, job) -> AgentState:
         return {
+            'run_id': job['run_id'],
             'url': job['app_url'],
             'credentials': job.get('credentials'),
+            'test_config': job.get('test_config'),
             'current_page': None,
             'screenshots': [],
             'screenshot_paths': [],
@@ -1141,8 +1190,13 @@ class JobRunner:
 {
   "run_id": "uuid",
   "app_url": "https://example.com",
-  "credentials": { "username": "...", "password": "...", "login_flow": [...] },
-  "enqueued_at": "2026-03-26T12:00:00Z"
+  "credentials": { "username": "...", "password": "..." },
+  "test_config": {
+    "max_pages": 10,
+    "instructions": "Test the client listing page",
+    "focus_areas": "authentication, forms"
+  },
+  "enqueued_at": "2026-03-29T12:00:00Z"
 }
 ```
 
@@ -1317,7 +1371,7 @@ Python runner.poll()
 | REDIS_URL | Yes | — | Redis connection string |
 | BACKEND_URL | Yes | http://localhost:5000 | Backend base URL |
 | AGENT_API_SECRET | Yes | — | Shared secret for PATCH /api/runs |
-| AGENT_MAX_PAGES | No | 5 | Max pages to explore per run |
+| AGENT_MAX_PAGES | No | 5 | Default max pages per run (overridable per-run via `test_config.max_pages`) |
 | AWS_ACCESS_KEY_ID | No | — | S3 screenshot upload |
 | AWS_SECRET_ACCESS_KEY | No | — | S3 screenshot upload |
 | S3_BUCKET | No | — | S3 bucket name |
@@ -1336,6 +1390,8 @@ Python runner.poll()
 | CREDENTIALS_ENCRYPTION_KEY | Yes | 64-char hex string (32 bytes) |
 | FRONTEND_URL | Yes | CORS allowed origin |
 | AGENT_API_SECRET | Yes | Shared secret for agent auth |
+| KF_EMAIL | No | Email for Korn Ferry Talent auto-registration on startup |
+| KF_IDP_PASSWORD | No | IDP password for Korn Ferry Talent auto-registration on startup |
 
 ### Generating Secrets
 

--- a/documents/TECHNICAL_SPEC.md
+++ b/documents/TECHNICAL_SPEC.md
@@ -1,6 +1,6 @@
 # BugHunter.AI — Technical Specification
 
-> Version: 1.1 | Date: 2026-03-29 | Codebase: `bughunter-ai`
+> Version: 1.3 | Date: 2026-03-30 | Codebase: `bughunter-ai`
 
 ---
 
@@ -93,7 +93,12 @@ bughunter-ai/
 │   │   ├── __init__.py
 │   │   ├── browser.py                # Synchronous Playwright wrapper
 │   │   ├── screenshot.py             # Screenshot capture + S3 upload
-│   │   └── storage.py                # PostgreSQL persistence (psycopg2)
+│   │   ├── storage.py                # PostgreSQL persistence (psycopg2)
+│   │   ├── events.py                 # Redis pub/sub for SSE progress
+│   │   ├── memory.py                 # Per-app memory load/save + fingerprints
+│   │   ├── json_utils.py             # Extract JSON from LLM output
+│   │   ├── bug_dedupe.py             # Deduplicate bugs before reporting
+│   │   └── pipeline_log.py           # Compact test_steps timeline for DB summary
 │   ├── worker/
 │   │   ├── __init__.py
 │   │   └── runner.py                 # JobRunner — Redis BLPOP poller
@@ -141,14 +146,23 @@ bughunter-ai/
 │       ├── services/
 │       │   └── api.js                # Axios client with interceptors
 │       ├── context/
-│       │   └── AuthContext.jsx       # Auth state + login/register/logout
+│       │   ├── AuthContext.jsx       # Auth state + login/register/logout
+│       │   └── SidebarContext.jsx    # Collapsed sidebar state
+│       ├── data/
+│       │   ├── agentProfiles.js      # Static copy for AI Agents page
+│       │   └── liveEventConfig.js    # SSE event type icons/colors (shared)
 │       └── components/
 │           ├── Dashboard.jsx         # Stats + recent runs home page
 │           ├── Sidebar.jsx           # Navigation sidebar
 │           ├── AppList.jsx           # App registration CRUD
 │           ├── TestRuns.jsx          # Test run list + creation
-│           ├── BugReports.jsx        # Bug view for a run
-│           └── NewRunModal.jsx       # Modal to trigger a new run
+│           ├── BugReports.jsx        # Run detail: pipeline, live activity, agent logs, bugs
+│           ├── AgentPipelineTracker.jsx  # 5-step agent progress (run + overview modes)
+│           ├── AgentActivityLog.jsx  # Events grouped/filtered by agent
+│           ├── AgentProfiles.jsx     # /agents — cards for each pipeline agent
+│           ├── NewRunModal.jsx       # Modal to trigger a new run
+│           ├── AppHeader.jsx / AppFooter.jsx / UserProfile.jsx / ApiTesting.jsx
+│           └── ...
 │
 ├── database/
 │   ├── migrations/
@@ -156,7 +170,9 @@ bughunter-ai/
 │   │   ├── 002_apps.sql
 │   │   ├── 003_test_runs.sql
 │   │   ├── 004_bug_reports.sql
-│   │   └── 005_not_null_constraints.sql
+│   │   ├── 005_not_null_constraints.sql
+│   │   ├── 006_credentials_text.sql
+│   │   └── 007_app_memory.sql
 │   ├── migrate.sh
 │   └── scripts/
 │       └── re_encrypt_credentials.js # Credential key rotation utility
@@ -285,7 +301,7 @@ Login flow actions: `fill` | `click` | `wait_for_navigation` | `wait_for_selecto
 ### 4.3 `test_runs`
 
 ```sql
-CREATE TYPE run_status AS ENUM ('pending', 'running', 'completed', 'failed');
+CREATE TYPE run_status AS ENUM ('pending', 'running', 'completed', 'failed', 'paused', 'cancelled');
 
 CREATE TABLE test_runs (
   id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -308,7 +324,7 @@ CREATE INDEX idx_test_runs_status  ON test_runs(status);
 | id | UUID | PK |
 | app_id | UUID | FK → apps(id), NOT NULL |
 | user_id | UUID | FK → users(id), NOT NULL |
-| status | run_status ENUM | pending → running → completed/failed |
+| status | run_status ENUM | pending → running → completed / failed / cancelled; paused (mid-run suspension) |
 | started_at | TIMESTAMPTZ | Set when agent picks up job |
 | completed_at | TIMESTAMPTZ | Set on completion/failure |
 | summary | JSONB | `{ total_bugs, pages_explored, screenshots_taken }` |
@@ -521,6 +537,9 @@ Response `200`: `{ "message": "App deleted", "id": "uuid" }`
 | GET | /api/runs/:id | JWT | Get run + its bugs |
 | PATCH | /api/runs/:id | Agent secret | Agent updates run status |
 | DELETE | /api/runs/:id | JWT | Delete run + bugs |
+| POST | /api/runs/:id/stop    | JWT | Stop active run (sets Redis signal, marks cancelled) |
+| POST | /api/runs/:id/pause   | JWT | Pause active run (sets Redis signal, marks paused) |
+| POST | /api/runs/:id/resume  | JWT | Resume paused run (clears Redis signal, marks running) |
 
 ---
 
@@ -588,13 +607,14 @@ Authentication via header: `x-agent-secret: <AGENT_API_SECRET>`
 Request:
 ```json
 {
-  "status": "running" | "completed" | "failed",
+  "status": "running" | "completed" | "failed" | "paused" | "cancelled",
   "summary": { "total_bugs": 5, "pages_explored": 3, "screenshots_taken": 10 },
   "error": "Optional error string"
 }
 ```
 
 Called internally by the Python agent after the LangGraph pipeline completes.
+The persisted `test_runs.summary` JSON (written by the agent via `save_run_to_db`, not only this PATCH) may include: `strategic_plan`, `visited_urls`, `dedupe_stats`, `pipeline_log` — see §7.8.
 
 ---
 
@@ -691,7 +711,7 @@ decrypt(ciphertext) // ciphertext string → JS object
 
 ### 5.5 Queue (`queue/testQueue.js`)
 
-**BullMQ Queue Name:** `test-runs`
+**BullMQ Queue Name:** `bughunter-tests`
 
 **Job options:**
 ```javascript
@@ -704,7 +724,7 @@ decrypt(ciphertext) // ciphertext string → JS object
 
 **`enqueueTestRun(runId, appUrl, credentials, testConfig)`** does two things:
 1. `RPUSH bughunter:jobs <json>` — consumed by Python via BLPOP
-2. `queue.add('run', payload, options)` — BullMQ for monitoring/retries
+2. `queue.add('run-test', payload, options)` — BullMQ for monitoring/retries
 
 ---
 
@@ -751,6 +771,9 @@ decrypt(ciphertext) // ciphertext string → JS object
 | /apps | AppList | Yes |
 | /runs | TestRuns | Yes |
 | /runs/:id | BugReports | Yes |
+| /agents | AgentProfiles | Yes |
+| /apitest | ApiTesting | Yes |
+| /profile | UserProfile | Yes |
 | * | → / redirect | — |
 
 `ProtectedRoute` wrapper checks `user` context; redirects to `/login` if unauthenticated.
@@ -802,6 +825,9 @@ Navigation links:
 - Dashboard (`/`)
 - My Apps (`/apps`)
 - Test Runs (`/runs`)
+- AI Agents (`/agents`) — static agent descriptions + pipeline overview
+- API Testing (`/apitest`)
+- Profile (`/profile`)
 - Logout button
 
 #### `AppList.jsx`
@@ -812,6 +838,7 @@ Navigation links:
   2. **Smart Login (Auto)** — email + password; agent drives login via LLM
   3. **SSO / Multi-Step** — `LoginFlowBuilder` component (manual override)
 - `LoginFlowBuilder` sub-component: dynamically add/remove/reorder login steps; each step has `action`, `selector`, `value`, `timeout` fields
+- **Run** button per app row opens NewRunModal pre-selected with that app
 - Delete app with confirmation
 
 #### `TestRuns.jsx`
@@ -819,25 +846,37 @@ Navigation links:
 - Paginated list of test runs
 - Filter by `app_id` and `status` via query params
 - **New Run** button opens `NewRunModal`
-- Auto-polls every 5 seconds while any run is pending/running
-- Delete run button
+- Auto-polls every 5 seconds while any run is pending/running/paused
+- Active rows (pending/running/paused) show a **Stop** button instead of delete
 
 #### `BugReports.jsx`
 
-- Displays all bugs for a specific run (from `/api/runs/:id`)
+- Loads run + bugs from `GET /api/runs/:id`
+- **Agent pipeline** — `AgentPipelineTracker` (live progress from SSE `agent_start` / `agent_done` with optional `clientTs` on events)
+- **Live Activity / Activity Log** — flat chronological SSE stream (`GET /api/runs/:id/stream?token=…`); events cached in `localStorage` (last 500)
+- **Agent logs** — `AgentActivityLog`: same events grouped by agent phase with filter pills
 - Filter bar: critical / high / medium / low severity buttons
-- `BugCard` sub-component: expandable card showing full bug details (title, description, steps, expected/actual, severity badge, status dropdown, screenshot link)
-- Status dropdown: update bug status inline via `PUT /api/bugs/:id/status`
+- `BugCard` sub-component: expandable card (title, description, steps, severity, status, screenshot)
+- Status updates via `PUT /api/bugs/:id/status`
+- **Stop** button shown for `pending`/`running` runs; **Pause** button for `running` only; **Resume** + **Stop** for `paused`
+- SSE event types handled: `run_stopped`, `run_cancelled`, `run_paused`, `run_resumed`
+
+#### `AgentProfiles.jsx` (`/agents`)
+
+- Static content from `src/data/agentProfiles.js`: pipeline order, capability chips, tools per agent
 
 #### `NewRunModal.jsx`
 
 - Modal overlay
+- Accepts optional `defaultAppId` prop — when passed, that app is pre-selected in the dropdown (used by the **Run** button on `AppList`)
 - Loads app list on mount
 - Select app from dropdown
 - **Test Configuration section:**
   - *What to test* — free-text instructions passed to the agent (e.g. `"Test client listing page — search, filters, pagination"`)
   - *Focus areas* — comma-separated areas to prioritize (e.g. `"authentication, forms"`)
   - *Pages to explore* — range slider 1–20 (default 5)
+  - *Capture login step screenshots* toggle — screenshot after each auto-login step (default **on**)
+  - *Detailed AI report* toggle — AI enriches each bug with structured report; off = **quick mode** (bugs logged directly without LLM enrichment, uses `SimpleReporterAgent`) (default **off**)
 - Optional *Notes* field for run-level record-keeping
 - Sends `test_config` object in `POST /api/runs` body
 - On success, redirects user to `/runs/:newRunId`
@@ -851,13 +890,14 @@ Navigation links:
   plugins: [react()],
   server: {
     proxy: {
-      '/api': { target: 'http://localhost:5000', changeOrigin: true }
+      '/api': { target: 'http://localhost:5000', changeOrigin: true },
+      '/screenshots': { target: 'http://localhost:5000', changeOrigin: true }
     }
   }
 }
 ```
 
-Dev server proxies `/api/*` to backend port 5000.
+Dev server proxies `/api/*` and `/screenshots/*` to backend port 5000.
 
 ---
 
@@ -899,8 +939,11 @@ Reads `LLM_PROVIDER` and `LLM_MODEL` from env. Returns a LangChain `Chat*` model
 | groq | langchain-groq | GROQ_API_KEY | llama-3.3-70b-versatile |
 | mistral | langchain-mistralai | MISTRAL_API_KEY | mistral-large-latest |
 | ollama | langchain-ollama | OLLAMA_BASE_URL | llama3 |
+| claude_cli | subprocess CLI | — | claude-sonnet-4-6 (see `providers.py`) |
 
 Temperature is fixed at 0.2 for consistent, deterministic LLM outputs.
+
+**SSE progress:** `tools/events.publish_event` writes to Redis channel `bughunter:run:{run_id}:progress`; the backend exposes `GET /api/runs/:id/stream` for the frontend.
 
 ---
 
@@ -915,12 +958,17 @@ class AgentState(TypedDict):
     current_page: Optional[str]        # Last visited URL
     screenshots: List[Dict]            # {label, base64, url, timestamp, local_path}
     screenshot_paths: List[str]        # Paths (after base64 stripped)
-    bugs_found: List[Dict]             # Raw bug observations (pre-report)
-    test_steps: List[Dict]             # {action, selector, value, result}
+    bugs_found: List[Dict]             # Raw observations; deduped before reporting
+    test_steps: List[Dict]             # plan, observe, errors_detected, login_*, etc.
     current_agent: Optional[str]       # Active agent name (for tracing)
     error: Optional[str]               # Error message if pipeline fails
     status: str                        # pending | running | completed | failed
     report: Optional[List[Dict]]       # Final structured bug reports
+    app_memory: Optional[Dict]         # Per-app memory from PostgreSQL
+    login_steps_for_memory: Optional[List[Dict]]  # Persisted login flow for next run
+    strategic_plan: Optional[Dict]     # Parsed orchestrator JSON (pages, journeys, focus_areas, notes)
+    visited_urls: Optional[List[str]]  # Explorer URLs — drives SecurityAgent multi-scan
+    dedupe_stats: Optional[Dict]       # {before, after, removed} from ReporterAgent
 ```
 
 **`test_config` shape:**
@@ -939,11 +987,11 @@ class AgentState(TypedDict):
 ```python
 def build_graph() -> CompiledGraph:
     graph = StateGraph(AgentState)
-    graph.add_node("orchestrator", orchestrate_node)
-    graph.add_node("explorer",     explore_node)
-    graph.add_node("validator",    validate_node)
+    graph.add_node("orchestrator", orchestrator_node)
+    graph.add_node("explorer",     explorer_node)
+    graph.add_node("validator",    validator_node)
     graph.add_node("security",     security_node)
-    graph.add_node("reporter",     report_node)
+    graph.add_node("reporter",     reporter_node)
 
     graph.set_entry_point("orchestrator")
     graph.add_edge("orchestrator", "explorer")
@@ -964,13 +1012,13 @@ All edges are **deterministic** — no conditional branching. Every run executes
 Each node is a thin wrapper:
 
 ```python
-def orchestrate_node(state: AgentState) -> AgentState:
+def orchestrator_node(state: AgentState) -> AgentState:
     return OrchestratorAgent().run(state)
 
-def explore_node(state: AgentState) -> AgentState:
+def explorer_node(state: AgentState) -> AgentState:
     return ExplorerAgent().run(state)
 
-# ... same pattern for validate_node, security_node, report_node
+# ... same pattern for validator_node, security_node, reporter_node
 ```
 
 ---
@@ -979,41 +1027,44 @@ def explore_node(state: AgentState) -> AgentState:
 
 #### OrchestratorAgent (`agents/orchestrator.py`)
 
-**Input:** `url`, `credentials`, `test_config`
+**Input:** `url`, `credentials`, `test_config`, `app_memory`
 
 **Process:**
 1. Builds auth context description from credentials shape:
-   - No credentials → "No authentication required"
-   - `{username, password}` → "Smart auto-login with email + password"
+   - No credentials → anonymous testing
+   - `{username, password}` → simple credentials
    - `{login_flow}` → "Multi-step SSO/IDP flow (N steps)"
-2. Incorporates `test_config` into the planning prompt:
-   - `instructions` → appended as "User instructions: ..."
-   - `focus_areas` → appended as "Focus areas: ..."
-   - `max_pages` → appended as "Explorer will visit up to N page(s)"
-3. Calls `get_llm().invoke(prompt)` and receives a structured test strategy
+2. Incorporates `test_config` and **app memory** (known bugs, bug-prone pages) into the planning prompt.
+3. Asks the LLM for **JSON** with keys: `pages`, `user_journeys`, `focus_areas`, `notes` (paths may be relative or absolute).
+4. Parses JSON via `tools/json_utils.extract_json_from_text` into **`strategic_plan`**. On parse failure, stores raw text in `notes`.
 
 **Output mutations:**
-- `test_steps`: Appended with `{ "action": "plan", "result": <llm_response> }`
-- `status`: Set to `"running"`
+- `strategic_plan`: `{ pages, user_journeys, focus_areas, notes }`
+- `test_steps`: `{ "action": "plan", "detail": <raw_llm_text>, "agent": "orchestrator" }`
+- `status`: `"running"`
 
 ---
 
 #### ExplorerAgent (`agents/explorer.py`)
 
-**Input:** `url`, `credentials`, `test_config`, `test_steps` (plan)
+**Input:** `url`, `credentials`, `test_config`, `test_steps` (includes plan step), **`strategic_plan`**
 
 **Process:**
 1. Launches headless Chromium (1280×800 viewport)
 2. Reads `test_config.max_pages` (falls back to `AGENT_MAX_PAGES` env var, default 5)
-3. If credentials provided, selects login strategy:
+3. **URL priority:** Normalizes `strategic_plan.pages` to same-origin absolute URLs, then **merges** with `build_page_priority_list(app_memory)` (historically bug-prone pages). Orchestrator URLs are tried first.
+4. If credentials provided, selects login strategy:
    - **Option A — SSO / Multi-Step** (`credentials.login_flow`): Execute each pre-configured step in sequence. Dismiss overlays before each step. Retry with `force=True` on overlay-blocked clicks.
    - **Option B — Smart Login (Auto)** (`credentials.username` + `credentials.password`): LLM-driven iterative login loop (see below).
 4. Navigate up to `max_pages` pages within the same domain
 5. For each page:
    - Capture full-page screenshot
-   - Ask LLM what to test (incorporating `test_config.instructions` and `test_config.focus_areas`)
+   - Call `inspect_page_structure()` — runs DOM queries via `page.evaluate()` to extract structured data: headings, forms with field labels/types, tables with headers + row count, and key-value pairs
+   - Ask LLM what to test (`_ask_what_to_test(page_structure)`) — prompt now shows structured sections (Page sections, Forms, Data tables, Key data) instead of raw truncated HTML; also includes **`strategic_plan`** (notes, user journeys, orchestrator `focus_areas`) and `test_config.instructions` / `focus_areas`
+   - Append `observe` step (including `"page_structure"` key alongside `detail`, `screenshot_label`, etc.) and (when present) `errors_detected` steps for ValidatorAgent
    - Log console errors and network failures
    - Collect all links for further exploration
+   - Check control signal (`check_run_control`) at the top of each page loop iteration; call `wait_while_paused()` on pause signal
 6. Close browser
 
 **Smart Login loop (Option B):**
@@ -1036,6 +1087,7 @@ The real password is **never sent to the LLM**. Works for:
 - `screenshots`: Array of `{ label, base64, url, timestamp, local_path }`
 - `test_steps`: Navigation steps, per-iteration smart login records, error observations
 - `current_page`: Last URL visited
+- `visited_urls`: Ordered list of URLs visited (used by SecurityAgent)
 
 ---
 
@@ -1064,49 +1116,13 @@ The real password is **never sent to the LLM**. Works for:
 
 #### SecurityAgent (`agents/security.py`)
 
-**Input:** `url`, `screenshots`, `test_steps`
+**Input:** `url`, **`visited_urls`** (from Explorer)
 
-**Tests performed:**
+**Target URLs:** Deduped list of `url` plus `visited_urls`, capped by **`SECURITY_MAX_URLS`** (default `6`; set in `agent/.env`).
 
-**1. XSS Injection (`_test_xss`)**
+**Per URL:** One browser session runs XSS probes, then SQLi probes, then a regex **secret** scan on the final HTML. First 3 form inputs; 2 XSS payloads and 2 SQLi payloads per input (same payload sets as before).
 
-Payloads (5 total, 2 tested per input):
-```python
-"<script>alert('XSS')</script>"
-'"><script>alert(1)</script>'
-"javascript:alert(1)"
-"<img src=x onerror=alert(1)>"
-"';alert(1)//"
-```
-
-- Tests first 3 form inputs on the page
-- Checks if payload appears unescaped in response HTML
-
-**2. SQL Injection (`_test_sqli`)**
-
-Payloads (5 total, 2 tested per input):
-```python
-"' OR '1'='1"
-"' OR 1=1--"
-'" OR ""="'
-"1; DROP TABLE users--"
-"admin'--"
-```
-
-- Tests first 3 form inputs
-- Checks page source for SQL error signatures: `SQL syntax`, `mysql_fetch`, `ORA-`, `syntax error`
-
-**3. Exposed Secrets (`_check_exposed_secrets`)**
-
-Regex patterns checked against page source:
-```python
-r"(?i)(api[_-]?key|apikey)\s*[=:]\s*['\"]?[\w\-]{16,}"
-r"(?i)(secret[_-]?key|secretkey)\s*[=:]\s*['\"]?[\w\-]{16,}"
-r"(?i)(password|passwd|pwd)\s*[=:]\s*['\"]?\w{6,}"
-r"(?i)aws[_-]?(access[_-]?key|secret)\s*[=:]\s*['\"]?[\w/+=]{16,}"
-```
-
-All security bugs are marked `severity: "critical"`.
+**Secret findings:** Severity **`high`** (not critical) with copy noting possible false positives.
 
 **Output mutations:**
 - `bugs_found`: Appended with security findings
@@ -1115,10 +1131,11 @@ All security bugs are marked `severity: "critical"`.
 
 #### ReporterAgent (`agents/reporter.py`)
 
-**Input:** `bugs_found`, `url`
+**Input:** `bugs_found`, `app_memory` (for regression fingerprints)
 
 **Process:**
-1. For each entry in `bugs_found`, calls LLM with a structured prompt
+1. **`dedupe_bugs`** (`tools/bug_dedupe.py`) — removes duplicate observations by `make_fingerprint(title, page_url)`; records **`dedupe_stats`** `{ before, after, removed }`.
+2. For each remaining entry, calls LLM with a structured prompt
 2. LLM returns a fully structured bug report with:
    - `title` — concise bug title
    - `description` — full description
@@ -1131,7 +1148,9 @@ All security bugs are marked `severity: "critical"`.
 3. Builds final `report` list
 
 **Output mutations:**
+- `bugs_found`: Replaced with deduped list (aligned with reports)
 - `report`: Final list of structured bug report dicts
+- `dedupe_stats`: Deduplication counts
 - `status`: Set to `"completed"`
 
 ---
@@ -1159,9 +1178,14 @@ class JobRunner:
         try:
             initial_state = self._build_state(job)
             final_state = self.graph.invoke(initial_state)
-            save_run_to_db(job['run_id'], 'completed', final_state)
+            # Determine final status: cancelled if a stop signal was set, otherwise completed
+            was_stopped = check_run_control(job['run_id']) == SIGNAL_STOP
+            final_status = 'cancelled' if was_stopped else 'completed'
+            save_run_to_db(job['run_id'], final_status, final_state)
         except Exception as exc:
             save_run_to_db(job['run_id'], 'failed', {'error': str(exc)})
+        finally:
+            clear_run_control(job['run_id'])  # Always clear the control key
 
     def _update_run_status(self, run_id, status):
         # PATCH /api/runs/:id with x-agent-secret header
@@ -1180,8 +1204,13 @@ class JobRunner:
             'test_steps': [],
             'current_agent': None,
             'error': None,
-            'status': 'pending',
+            'status': 'running',
             'report': None,
+            'app_memory': load_memory(app_id) if app_id else {},
+            'login_steps_for_memory': None,
+            'strategic_plan': None,
+            'visited_urls': None,
+            'dedupe_stats': None,
         }
 ```
 
@@ -1223,6 +1252,7 @@ Synchronous Playwright wrapper using `sync_playwright()`.
 | `get_title()` | Return page title |
 | `get_all_links()` | Return all `<a href>` targets |
 | `get_form_inputs()` | Return CSS selectors of form inputs |
+| `inspect_page_structure()` | Return structured page data: headings, forms with field labels/types, tables with headers + row count, key-value pairs. Runs DOM queries via `page.evaluate()` |
 | `get_console_errors()` | Return JS console error messages |
 | `get_network_errors()` | Return failed network request URLs |
 | `close()` | Close browser and Playwright context |
@@ -1233,6 +1263,24 @@ Synchronous Playwright wrapper using `sync_playwright()`.
 - `[class*='consent'] button`
 - `[class*='modal'] button[class*='close']`
 - `button[aria-label='Close']`
+
+---
+
+#### `tools/control.py` — Run Control Signals
+
+Redis-based mechanism for stopping or pausing active runs.
+
+**Key:** `bughunter:control:{run_id}` — set by the backend; TTL 1 hour.
+
+**Values:** `"stop"` | `"pause"`
+
+| Function | Description |
+|---|---|
+| `check_run_control(run_id)` | Returns current signal string or `None` |
+| `wait_while_paused(run_id)` | Blocks until signal is no longer `"pause"`; returns `True` if stopped while waiting |
+| `clear_run_control(run_id)` | Deletes the key (called in `finally` block of `runner.poll()`) |
+
+All five agents check the stop signal at entry and return early if stopped. ExplorerAgent additionally checks at the top of every page loop iteration and calls `wait_while_paused()` on pause.
 
 ---
 
@@ -1256,6 +1304,12 @@ def upload_to_s3(image_data, run_id: str, label: str) -> Optional[str]
 
 ---
 
+#### `tools/bug_dedupe.py` / `tools/pipeline_log.py` / `tools/json_utils.py`
+
+- **`dedupe_bugs(bugs)`** — fingerprint-based deduplication before ReporterAgent LLM calls.
+- **`build_pipeline_log(test_steps)`** — compact step timeline stored in `test_runs.summary`.
+- **`extract_json_from_text(text)`** — used by OrchestratorAgent to parse strategic JSON.
+
 #### `tools/storage.py`
 
 ```python
@@ -1268,14 +1322,20 @@ Uses `psycopg2.pool.ThreadedConnectionPool` (min=1, max=5).
 
 1. `UPDATE test_runs SET status=..., completed_at=NOW(), summary=..., error=... WHERE id=...`
 
-   Summary JSONB:
+   Summary JSONB (extended):
    ```json
    {
-     "total_bugs": <len(report)>,
-     "pages_explored": <unique urls in test_steps>,
-     "screenshots_taken": <len(screenshots)>
+     "total_bugs": <len(bugs_found after dedupe)>,
+     "pages_explored": <unique pages from screenshots>,
+     "screenshots_taken": <len(screenshots)>,
+     "pages_visited": [ ... ],
+     "strategic_plan": { "pages": [], "user_journeys": [], "focus_areas": "", "notes": "" },
+     "visited_urls": [ "https://..." ],
+     "dedupe_stats": { "before": 12, "after": 9, "removed": 3 },
+     "pipeline_log": [ { "agent": "explorer", "action": "observe", "url": "..." } ]
    }
    ```
+   `pipeline_log` is produced by `tools/pipeline_log.build_pipeline_log(test_steps)` (truncated list for tuning/debugging).
 
 2. For each item in `results['report']`:
    ```sql
@@ -1372,6 +1432,7 @@ Python runner.poll()
 | BACKEND_URL | Yes | http://localhost:5000 | Backend base URL |
 | AGENT_API_SECRET | Yes | — | Shared secret for PATCH /api/runs |
 | AGENT_MAX_PAGES | No | 5 | Default max pages per run (overridable per-run via `test_config.max_pages`) |
+| SECURITY_MAX_URLS | No | 6 | Max URLs for XSS/SQLi/secret scans (seed + explorer `visited_urls`) |
 | AWS_ACCESS_KEY_ID | No | — | S3 screenshot upload |
 | AWS_SECRET_ACCESS_KEY | No | — | S3 screenshot upload |
 | S3_BUCKET | No | — | S3 bucket name |
@@ -1479,7 +1540,9 @@ psql postgresql://postgres:postgres@localhost:5432/bughunter \
   -f database/migrations/002_apps.sql \
   -f database/migrations/003_test_runs.sql \
   -f database/migrations/004_bug_reports.sql \
-  -f database/migrations/005_not_null_constraints.sql
+  -f database/migrations/005_not_null_constraints.sql \
+  -f database/migrations/006_credentials_text.sql \
+  -f database/migrations/007_app_memory.sql
 
 # 3. Backend
 cd backend && npm install
@@ -1519,4 +1582,4 @@ Convenience script that launches all three services in separate PowerShell windo
 
 ---
 
-*This document was auto-generated from the BugHunter.AI source code on 2026-03-26.*
+*Document maintained against the BugHunter.AI source code. Last updated: 2026-03-29.*

--- a/documents/TECHNICAL_SPEC.md
+++ b/documents/TECHNICAL_SPEC.md
@@ -1,6 +1,6 @@
 # BugHunter.AI — Technical Specification
 
-> Version: 1.3 | Date: 2026-03-30 | Codebase: `bughunter-ai`
+> Version: 1.4 | Date: 2026-03-31 | Codebase: `bughunter-ai`
 
 ---
 
@@ -132,6 +132,8 @@ bughunter-ai/
 │       │   ├── apps.routes.js
 │       │   ├── runs.routes.js
 │       │   └── bugs.routes.js
+│       ├── jobs/
+│       │   └── staleRunReaper.js     # Background reaper for ghost runs
 │       └── queue/
 │           └── testQueue.js          # BullMQ Queue + raw Redis list
 │
@@ -147,7 +149,8 @@ bughunter-ai/
 │       │   └── api.js                # Axios client with interceptors
 │       ├── context/
 │       │   ├── AuthContext.jsx       # Auth state + login/register/logout
-│       │   └── SidebarContext.jsx    # Collapsed sidebar state
+│       │   ├── SidebarContext.jsx    # Collapsed sidebar state
+│       │   └── NotificationContext.jsx # Global toast notifications
 │       ├── data/
 │       │   ├── agentProfiles.js      # Static copy for AI Agents page
 │       │   └── liveEventConfig.js    # SSE event type icons/colors (shared)
@@ -161,6 +164,7 @@ bughunter-ai/
 │           ├── AgentActivityLog.jsx  # Events grouped/filtered by agent
 │           ├── AgentProfiles.jsx     # /agents — cards for each pipeline agent
 │           ├── NewRunModal.jsx       # Modal to trigger a new run
+│           ├── ErrorBoundary.jsx      # React error boundary with recovery UI
 │           ├── AppHeader.jsx / AppFooter.jsx / UserProfile.jsx / ApiTesting.jsx
 │           └── ...
 │
@@ -1083,9 +1087,15 @@ The real password is **never sent to the LLM**. Works for:
 - Email-first pages (password appears on second page)
 - SSO/IDP redirects (Microsoft Entra, Okta, Google)
 
+**Additional per-page checks:**
+- **Form Fuzzing** (`_fuzz_forms()`): Tests up to 3 form inputs with edge-case payloads (empty string, 5000-char string, special characters, unicode, negative numbers, `<script>` tag, SQL single quote). Submits form and checks for error indicators in page source and console errors.
+- **Performance Checks** (`_check_performance()`): Uses Navigation Timing API via `page.evaluate()` to measure `dom_content_loaded`, `load_complete`, and `ttfb`. Flags pages with >5000ms load time or >2000ms TTFB.
+- **Accessibility Audits** (`_check_accessibility()`): Uses `page.evaluate()` to check for: images without alt text, form inputs without labels/aria-labels, buttons without accessible text, missing `<html lang>` attribute, heading level skips (e.g. h1 → h3).
+
 **Output mutations:**
 - `screenshots`: Array of `{ label, base64, url, timestamp, local_path }`
-- `test_steps`: Navigation steps, per-iteration smart login records, error observations
+- `test_steps`: Navigation steps, per-iteration smart login records, error observations, fuzz/perf/a11y results
+- `bugs_found`: Appended with form fuzzing, performance, and accessibility bugs
 - `current_page`: Last URL visited
 - `visited_urls`: Ordered list of URLs visited (used by SecurityAgent)
 
@@ -1093,11 +1103,13 @@ The real password is **never sent to the LLM**. Works for:
 
 #### ValidatorAgent (`agents/validator.py`)
 
-**Input:** `screenshots`, `test_steps`
+**Input:** `screenshots`, `test_steps`, `app_memory`
 
 **Process:**
+
+Phase 1 — Text-based analysis:
 1. Iterates `test_steps` looking for `action == "observe"` or `action == "errors_detected"`
-2. For each relevant step, calls LLM with step data and associated screenshot context
+2. For each relevant step, calls LLM with step data and known bug context from `app_memory.known_bugs`
 3. LLM identifies bugs from the categories:
    - HTTP 404 / 5xx errors
    - Broken layouts or missing UI elements
@@ -1107,25 +1119,46 @@ The real password is **never sent to the LLM**. Works for:
    - Incorrect or missing data
    - Accessibility violations
 
-**Note:** Strips `base64` from screenshots at this stage (retains `local_path`) to reduce state size.
+Phase 2 — Vision-based analysis:
+1. Iterates `screenshots` that have `base64` data
+2. Sends each screenshot as a **multimodal `HumanMessage`** with `image_url` content type
+3. LLM analyzes the visual screenshot for visual-only bugs:
+   - Broken or misaligned layouts
+   - Missing images or icons
+   - Text overflow or truncation
+   - Visual inconsistencies
+4. Filters out low-confidence results
+5. Checks `SIGNAL_STOP` between screenshots for cancellation support
+
+**Note:** Strips `base64` from screenshots after validation to reduce state size.
 
 **Output mutations:**
-- `bugs_found`: Appended with LLM-identified bug observations
+- `bugs_found`: Appended with both text-based and vision-identified bug observations
 
 ---
 
 #### SecurityAgent (`agents/security.py`)
 
-**Input:** `url`, **`visited_urls`** (from Explorer)
+**Input:** `url`, **`visited_urls`** (from Explorer), `app_memory`, `skills`
 
 **Target URLs:** Deduped list of `url` plus `visited_urls`, capped by **`SECURITY_MAX_URLS`** (default `6`; set in `agent/.env`).
 
-**Per URL:** One browser session runs XSS probes, then SQLi probes, then a regex **secret** scan on the final HTML. First 3 form inputs; 2 XSS payloads and 2 SQLi payloads per input (same payload sets as before).
+**Adaptive Payloads:** Before scanning, builds XSS and SQLi payload lists from:
+- Default hardcoded payloads
+- Previously effective payloads from `app_memory.known_bugs` (security type bugs)
+- Learned payloads from `agent_skills` table (skill_type = `effective_payload`)
+
+**Per URL:** One browser session runs XSS probes, then SQLi probes, then a regex **secret** scan on the final HTML. First 3 form inputs; adaptive XSS and SQLi payloads per input.
+
+**Additional checks** (run once on seed URL after URL scanning):
+- **HTTP Security Headers:** Checks for HSTS, X-Content-Type-Options, X-Frame-Options, Content-Security-Policy
+- **Cookie Security:** Checks HttpOnly, Secure (on HTTPS), SameSite flags on all cookies
+- **CSRF Protection:** Uses `page.evaluate()` to find POST forms missing CSRF tokens (checks for input names containing csrf/token/_token/authenticity_token)
 
 **Secret findings:** Severity **`high`** (not critical) with copy noting possible false positives.
 
 **Output mutations:**
-- `bugs_found`: Appended with security findings
+- `bugs_found`: Appended with security findings (XSS, SQLi, secrets, headers, cookies, CSRF)
 
 ---
 
@@ -1134,7 +1167,7 @@ The real password is **never sent to the LLM**. Works for:
 **Input:** `bugs_found`, `app_memory` (for regression fingerprints)
 
 **Process:**
-1. **`dedupe_bugs`** (`tools/bug_dedupe.py`) — removes duplicate observations by `make_fingerprint(title, page_url)`; records **`dedupe_stats`** `{ before, after, removed }`.
+1. **`dedupe_bugs`** (`tools/bug_dedupe.py`) — removes duplicate observations using both fingerprint matching and **semantic similarity** (SequenceMatcher, threshold 0.70 for titles and descriptions on same page/type); records **`dedupe_stats`** `{ before, after, removed, semantic_removed }`.
 2. For each remaining entry, calls LLM with a structured prompt
 2. LLM returns a fully structured bug report with:
    - `title` — concise bug title
@@ -1207,12 +1240,21 @@ class JobRunner:
             'status': 'running',
             'report': None,
             'app_memory': load_memory(app_id) if app_id else {},
+            'skills': load_agent_skills(app_id, 'all') if app_id else [],
+            'app_id': app_id,
             'login_steps_for_memory': None,
             'strategic_plan': None,
             'visited_urls': None,
             'dedupe_stats': None,
         }
 ```
+
+**Heartbeat:** During pipeline execution, a background thread writes a Redis key `bughunter:heartbeat:{run_id}` every 30 seconds with a 90-second TTL. This allows the backend's stale run reaper to detect crashed workers.
+
+**Post-run memory/skills:** After a successful (non-cancelled) run:
+1. `extract_memory_updates(final_state, app_memory)` — updates login steps, page priority scores, known bug fingerprints, run metadata
+2. `save_memory(app_id, updated_memory)` — persists to `app_memory` table
+3. `extract_and_save_skills(run_id, app_id, final_state)` — extracts page→bug_type patterns and effective security payloads into `agent_skills` table
 
 **Redis job format:**
 ```json
@@ -1306,7 +1348,7 @@ def upload_to_s3(image_data, run_id: str, label: str) -> Optional[str]
 
 #### `tools/bug_dedupe.py` / `tools/pipeline_log.py` / `tools/json_utils.py`
 
-- **`dedupe_bugs(bugs)`** — fingerprint-based deduplication before ReporterAgent LLM calls.
+- **`dedupe_bugs(bugs)`** — three-tier deduplication: (1) exact fingerprint match, (2) same page + title similarity >= 0.70 via `SequenceMatcher`, (3) same page + same type + description similarity >= 0.70. Merges severity (keeps highest). Tracks `semantic_removed` count.
 - **`build_pipeline_log(test_steps)`** — compact step timeline stored in `test_runs.summary`.
 - **`extract_json_from_text(text)`** — used by OrchestratorAgent to parse strategic JSON.
 
@@ -1451,6 +1493,8 @@ Python runner.poll()
 | CREDENTIALS_ENCRYPTION_KEY | Yes | 64-char hex string (32 bytes) |
 | FRONTEND_URL | Yes | CORS allowed origin |
 | AGENT_API_SECRET | Yes | Shared secret for agent auth |
+| LOG_LEVEL | No (default info) | Winston log level (error/warn/info/debug) |
+| RATE_LIMIT_MAX | No (default 100) | Max API requests per 15 minutes per IP |
 | KF_EMAIL | No | Email for Korn Ferry Talent auto-registration on startup |
 | KF_IDP_PASSWORD | No | IDP password for Korn Ferry Talent auto-registration on startup |
 
@@ -1486,8 +1530,9 @@ openssl rand -hex 32
 
 ### 10.3 Rate Limiting
 
-- Auth routes (`/api/auth/*`): 20 requests per 15 minutes per IP
-- All other routes: No explicit limit (backend inherits express defaults)
+- **Global API limiter** (`/api/*`): 100 requests per 15 minutes per IP (configurable via `RATE_LIMIT_MAX` env var)
+- Auth routes (`/api/auth/*`): Stricter — 20 requests per 15 minutes per IP
+- Health endpoint (`/health`): Excluded from rate limiting
 
 ### 10.4 Input Validation
 
@@ -1579,7 +1624,17 @@ Convenience script that launches all three services in separate PowerShell windo
 | Screenshot storage | Configure S3 to avoid local disk accumulation |
 | Secrets rotation | Use `database/scripts/re_encrypt_credentials.js` to re-encrypt after key rotation |
 | Monitoring | Add Bull Board (`@bull-board/express`) for queue visibility |
+| Rate limiting | Tune `RATE_LIMIT_MAX` env var for production traffic patterns |
+| Logging | Set `LOG_LEVEL=warn` in production to reduce log volume; logs are structured JSON |
+
+### Observability
+
+**Request logging:** Every HTTP request is logged with method, path, status code, duration (ms), and client IP. Status >= 500 logged as `error`, >= 400 as `warn`.
+
+**Deep health check:** `GET /health` probes PostgreSQL (`SELECT 1`) and Redis (`PING`). Returns `503` with `status: "degraded"` if either fails, including uptime in seconds.
+
+**Stale run reaper** (`backend/src/jobs/staleRunReaper.js`): Runs every 60 seconds. Finds runs in `running` status older than 3 minutes, checks their Redis heartbeat key (`bughunter:heartbeat:{run_id}`). If the heartbeat is missing or stale (> 90s), marks the run as `failed` with a descriptive error message. Prevents ghost runs when agent workers crash.
 
 ---
 
-*Document maintained against the BugHunter.AI source code. Last updated: 2026-03-29.*
+*Document maintained against the BugHunter.AI source code. Last updated: 2026-03-31.*

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { Link, Navigate, Route, Routes } from 'react-router-dom';
 import { useAuth } from './context/AuthContext.jsx';
+import { SidebarProvider, useSidebar } from './context/SidebarContext.jsx';
+import AppHeader from './components/AppHeader.jsx';
+import AppFooter from './components/AppFooter.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import Dashboard from './components/Dashboard.jsx';
 import AppList from './components/AppList.jsx';
 import TestRuns from './components/TestRuns.jsx';
 import BugReports from './components/BugReports.jsx';
+import BugList from './components/BugList.jsx';
 import ApiTesting from './components/ApiTesting.jsx';
+import UserProfile from './components/UserProfile.jsx';
+import AgentProfiles from './components/AgentProfiles.jsx';
 
 // ── Shared input style ───────────────────────────────────────────────────────
 const inputStyle = {
@@ -30,7 +36,7 @@ function AuthShell({ children }) {
         {/* Brand header */}
         <header style={{ marginBottom: '2.5rem', textAlign: 'center' }}>
           <div style={{ display: 'inline-flex', alignItems: 'center', gap: '12px', marginBottom: '1rem' }}>
-            <div style={{ width: '40px', height: '40px', background: 'var(--primary)', display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: '8px' }}>
+            <div style={{ width: '40px', height: '40px', background: 'var(--primary-button)', display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: '8px' }}>
               <span className="material-symbols-outlined" style={{ color: '#fff', fontVariationSettings: "'FILL' 1" }}>security</span>
             </div>
             <span style={{ fontSize: '1.5rem', fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--primary)' }}>BugHunter.AI</span>
@@ -75,7 +81,7 @@ function Login() {
 
   return (
     <AuthShell>
-      <div className="glass-card" style={{ borderRadius: '12px', padding: '2rem 2.5rem', borderLeft: '3px solid var(--primary)' }}>
+      <div className="glass-card" style={{ borderRadius: '8px', padding: '2rem 2.5rem', border: '1px solid var(--border-subtle)', borderLeft: '4px solid var(--secondary)' }}>
         {error && <ErrorBanner msg={error} />}
         <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
           {/* Email */}
@@ -100,7 +106,7 @@ function Login() {
           </div>
           {/* CTA */}
           <div style={{ paddingTop: '4px' }}>
-            <button type="submit" disabled={loading} style={{ width: '100%', padding: '14px', background: 'linear-gradient(135deg, var(--primary), var(--primary-container))', color: '#fff', border: 'none', borderRadius: '8px', fontSize: '0.95rem', fontWeight: 500, opacity: loading ? 0.7 : 1, letterSpacing: '0.01em' }}>
+            <button type="submit" disabled={loading} className="btn-primary" style={{ width: '100%', padding: '14px', fontSize: '0.95rem', opacity: loading ? 0.7 : 1 }}>
               {loading ? 'Signing in...' : 'Sign In'}
             </button>
           </div>
@@ -138,7 +144,7 @@ function Register() {
 
   return (
     <AuthShell>
-      <div className="glass-card" style={{ borderRadius: '12px', padding: '2rem 2.5rem', borderLeft: '3px solid var(--primary)' }}>
+      <div className="glass-card" style={{ borderRadius: '8px', padding: '2rem 2.5rem', border: '1px solid var(--border-subtle)', borderLeft: '4px solid var(--secondary)' }}>
         {error && <ErrorBanner msg={error} />}
         <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           {[
@@ -154,7 +160,7 @@ function Register() {
             </div>
           ))}
           <div style={{ paddingTop: '4px' }}>
-            <button type="submit" disabled={loading} style={{ width: '100%', padding: '14px', background: 'linear-gradient(135deg, var(--primary), var(--primary-container))', color: '#fff', border: 'none', borderRadius: '8px', fontSize: '0.95rem', fontWeight: 500, opacity: loading ? 0.7 : 1 }}>
+            <button type="submit" disabled={loading} className="btn-primary" style={{ width: '100%', padding: '14px', fontSize: '0.95rem', opacity: loading ? 0.7 : 1 }}>
               {loading ? 'Creating account...' : 'Create Account'}
             </button>
           </div>
@@ -168,23 +174,52 @@ function Register() {
   );
 }
 
+const SIDEBAR_EXPANDED = 260;
+const SIDEBAR_COLLAPSED = 72;
+
 // ── Protected Route ──────────────────────────────────────────────────────────
+function ProtectedShell({ children }) {
+  const { collapsed } = useSidebar();
+  const sidebarW = collapsed ? SIDEBAR_COLLAPSED : SIDEBAR_EXPANDED;
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--surface)' }}>
+      <AppHeader />
+      <Sidebar />
+      <div
+        className="app-main-shell"
+        style={{
+          marginLeft: sidebarW,
+          paddingTop: 'var(--header-height)',
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <main style={{ flex: 1, padding: '2rem 2.5rem', overflowY: 'auto', maxWidth: '1400px', width: '100%', margin: '0 auto' }}>
+          {children}
+        </main>
+        <div style={{ padding: '0 2.5rem 1.5rem', maxWidth: '1400px', width: '100%', margin: '0 auto' }}>
+          <AppFooter />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ProtectedRoute({ children }) {
   const { user, loading } = useAuth();
   if (loading) return (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', color: 'var(--on-surface-variant)', fontSize: '0.875rem', gap: '8px' }}>
-      <span className="material-symbols-outlined" style={{ color: 'var(--secondary)' }}>autorenew</span>
+      <span className="material-symbols-outlined" style={{ color: 'var(--link)' }}>autorenew</span>
       Loading...
     </div>
   );
   if (!user) return <Navigate to="/login" replace />;
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--surface)' }}>
-      <Sidebar />
-      <main style={{ marginLeft: '256px', minHeight: '100vh', padding: '2rem 2.5rem', overflowY: 'auto' }}>
-        {children}
-      </main>
-    </div>
+    <SidebarProvider>
+      <ProtectedShell>{children}</ProtectedShell>
+    </SidebarProvider>
   );
 }
 
@@ -198,7 +233,10 @@ export default function App() {
       <Route path="/apps"     element={<ProtectedRoute><AppList /></ProtectedRoute>} />
       <Route path="/runs"     element={<ProtectedRoute><TestRuns /></ProtectedRoute>} />
       <Route path="/runs/:id" element={<ProtectedRoute><BugReports /></ProtectedRoute>} />
+      <Route path="/bugs"     element={<ProtectedRoute><BugList /></ProtectedRoute>} />
+      <Route path="/agents"   element={<ProtectedRoute><AgentProfiles /></ProtectedRoute>} />
       <Route path="/apitest"  element={<ProtectedRoute><ApiTesting /></ProtectedRoute>} />
+      <Route path="/profile"  element={<ProtectedRoute><UserProfile /></ProtectedRoute>} />
       <Route path="*"         element={<Navigate to="/" replace />} />
     </Routes>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link, Navigate, Route, Routes } from 'react-router-dom';
 import { useAuth } from './context/AuthContext.jsx';
 import { SidebarProvider, useSidebar } from './context/SidebarContext.jsx';
+import { NotificationProvider } from './context/NotificationContext.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
 import AppHeader from './components/AppHeader.jsx';
 import AppFooter from './components/AppFooter.jsx';
 import Sidebar from './components/Sidebar.jsx';
@@ -226,18 +228,22 @@ function ProtectedRoute({ children }) {
 // ── App ──────────────────────────────────────────────────────────────────────
 export default function App() {
   return (
-    <Routes>
-      <Route path="/login"    element={<Login />} />
-      <Route path="/register" element={<Register />} />
-      <Route path="/"         element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
-      <Route path="/apps"     element={<ProtectedRoute><AppList /></ProtectedRoute>} />
-      <Route path="/runs"     element={<ProtectedRoute><TestRuns /></ProtectedRoute>} />
-      <Route path="/runs/:id" element={<ProtectedRoute><BugReports /></ProtectedRoute>} />
-      <Route path="/bugs"     element={<ProtectedRoute><BugList /></ProtectedRoute>} />
-      <Route path="/agents"   element={<ProtectedRoute><AgentProfiles /></ProtectedRoute>} />
-      <Route path="/apitest"  element={<ProtectedRoute><ApiTesting /></ProtectedRoute>} />
-      <Route path="/profile"  element={<ProtectedRoute><UserProfile /></ProtectedRoute>} />
-      <Route path="*"         element={<Navigate to="/" replace />} />
-    </Routes>
+    <ErrorBoundary>
+      <NotificationProvider>
+        <Routes>
+          <Route path="/login"    element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/"         element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+          <Route path="/apps"     element={<ProtectedRoute><AppList /></ProtectedRoute>} />
+          <Route path="/runs"     element={<ProtectedRoute><TestRuns /></ProtectedRoute>} />
+          <Route path="/runs/:id" element={<ProtectedRoute><BugReports /></ProtectedRoute>} />
+          <Route path="/bugs"     element={<ProtectedRoute><BugList /></ProtectedRoute>} />
+          <Route path="/agents"   element={<ProtectedRoute><AgentProfiles /></ProtectedRoute>} />
+          <Route path="/apitest"  element={<ProtectedRoute><ApiTesting /></ProtectedRoute>} />
+          <Route path="/profile"  element={<ProtectedRoute><UserProfile /></ProtectedRoute>} />
+          <Route path="*"         element={<Navigate to="/" replace />} />
+        </Routes>
+      </NotificationProvider>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/components/AgentActivityLog.jsx
+++ b/frontend/src/components/AgentActivityLog.jsx
@@ -1,0 +1,353 @@
+import React, { useMemo, useState, useEffect } from 'react';
+import { AGENT_PROFILES, PIPELINE_AGENT_IDS } from '../data/agentProfiles.js';
+import { EVENT_CONFIG } from '../data/liveEventConfig.js';
+
+// ─── Lightbox (minimal, matches BugReports pattern) ───────────────────────────
+
+function Lightbox({ src, label, onClose }) {
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.85)',
+        zIndex: 200,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: '90vw', maxHeight: '85vh', display: 'flex', flexDirection: 'column', gap: '10px' }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ color: '#fff', fontSize: '0.875rem', fontWeight: 500 }}>{label}</span>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              background: 'rgba(255,255,255,0.1)',
+              border: 'none',
+              color: '#fff',
+              borderRadius: '6px',
+              padding: '4px 10px',
+              cursor: 'pointer',
+              fontSize: '0.8rem',
+            }}
+          >
+            Close (Esc)
+          </button>
+        </div>
+        <img
+          src={src}
+          alt={label}
+          style={{ maxWidth: '100%', maxHeight: 'calc(85vh - 60px)', borderRadius: '8px', objectFit: 'contain' }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Walk events in order and assign each event to the current agent phase.
+ * @param {Array<Record<string, unknown>>} events
+ */
+function inferAgentPhase(events) {
+  /** @type {Array<Record<string, unknown> & { _phase?: string }>} */
+  const out = [];
+  let activeAgent = null;
+
+  for (const raw of events) {
+    const ev = { ...raw };
+    if (ev.type === 'agent_start' && ev.agent && PIPELINE_AGENT_IDS.includes(String(ev.agent))) {
+      activeAgent = String(ev.agent);
+      ev._phase = activeAgent;
+    } else if (ev.type === 'agent_done' && ev.agent && PIPELINE_AGENT_IDS.includes(String(ev.agent))) {
+      ev._phase = String(ev.agent);
+      out.push(ev);
+      activeAgent = null;
+      continue;
+    } else if (ev.type === 'run_complete' || ev.type === 'run_failed') {
+      ev._phase = 'pipeline';
+    } else {
+      ev._phase = activeAgent || 'pipeline';
+    }
+    out.push(ev);
+  }
+  return out;
+}
+
+function summarizeAgentEvents(agentId, agentEvents) {
+  let pages = 0;
+  let bugs = 0;
+  let logins = 0;
+  for (const ev of agentEvents) {
+    if (ev.type === 'page_visited') pages += 1;
+    if (ev.type === 'bug_found') bugs += 1;
+    if (ev.type === 'login_step') logins += 1;
+  }
+  const parts = [];
+  if (pages) parts.push(`${pages} page${pages === 1 ? '' : 's'} visited`);
+  if (bugs) parts.push(`${bugs} bug${bugs === 1 ? '' : 's'} flagged`);
+  if (logins) parts.push(`${logins} login step${logins === 1 ? '' : 's'}`);
+  return parts.length ? parts.join(' · ') : null;
+}
+
+/**
+ * @param {object} props
+ * @param {Array<Record<string, unknown>>} props.events
+ */
+export function AgentActivityLog({ events }) {
+  const [filter, setFilter] = useState('all');
+  const [open, setOpen] = useState(() => ({
+    ...Object.fromEntries(PIPELINE_AGENT_IDS.map((id) => [id, true])),
+    pipeline: true,
+  }));
+  const [lightbox, setLightbox] = useState(null);
+
+  const annotated = useMemo(() => inferAgentPhase(events), [events]);
+
+  const groups = useMemo(() => {
+    /** @type {Record<string, typeof annotated>} */
+    const g = Object.fromEntries(PIPELINE_AGENT_IDS.map((id) => [id, []]));
+    g.pipeline = [];
+
+    for (const ev of annotated) {
+      const phase = ev._phase === 'pipeline' ? 'pipeline' : PIPELINE_AGENT_IDS.includes(String(ev._phase)) ? String(ev._phase) : 'pipeline';
+      if (phase === 'pipeline') g.pipeline.push(ev);
+      else g[phase].push(ev);
+    }
+    return g;
+  }, [annotated]);
+
+  const durationForAgent = (agentId) => {
+    const list = groups[agentId] || [];
+    let start = null;
+    let end = null;
+    for (const ev of list) {
+      const ts =
+        typeof ev.clientTs === 'number'
+          ? ev.clientTs
+          : typeof ev.ts === 'number'
+            ? ev.ts
+            : null;
+      if (ev.type === 'agent_start' && ts != null) start = ts;
+      if (ev.type === 'agent_done' && ts != null) end = ts;
+    }
+    if (start != null && end != null && end >= start) {
+      const s = Math.round((end - start) / 1000);
+      if (s < 60) return `${s}s`;
+      const m = Math.floor(s / 60);
+      return `${m}m ${s % 60}s`;
+    }
+    return null;
+  };
+
+  const filterIds =
+    filter === 'all' ? [...PIPELINE_AGENT_IDS, 'pipeline'] : filter === 'pipeline' ? ['pipeline'] : [filter];
+
+  const pills = [
+    { id: 'all', label: 'All agents' },
+    ...AGENT_PROFILES.map((a) => ({ id: a.id, label: a.name })),
+    { id: 'pipeline', label: 'Run' },
+  ];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginBottom: '12px', alignItems: 'center' }}>
+        <span style={{ fontSize: '0.65rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+          Filter
+        </span>
+        {pills.map((p) => {
+          const active = filter === p.id;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setFilter(p.id)}
+              style={{
+                padding: '5px 12px',
+                borderRadius: '999px',
+                fontSize: '0.72rem',
+                fontWeight: active ? 600 : 500,
+                border: active ? 'none' : '1px solid var(--outline-variant)',
+                background: active ? 'var(--secondary-soft)' : 'transparent',
+                color: active ? 'var(--secondary)' : 'var(--on-surface-variant)',
+                cursor: 'pointer',
+              }}
+            >
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', maxHeight: '420px', overflowY: 'auto' }}>
+        {filterIds.map((agentId) => {
+          if (agentId === 'pipeline') {
+            const pipelineEvents = groups.pipeline || [];
+            if (pipelineEvents.length === 0) return null;
+            return (
+              <div
+                key="pipeline"
+                style={{
+                  borderRadius: '10px',
+                  border: '1px solid var(--outline-variant)',
+                  background: 'var(--surface-container-lowest)',
+                  overflow: 'hidden',
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={() => setOpen((o) => ({ ...o, pipeline: !o.pipeline }))}
+                  style={{
+                    width: '100%',
+                    padding: '10px 12px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    border: 'none',
+                    background: 'var(--surface-container)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                  }}
+                >
+                  <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--outline)' }}>
+                    flag
+                  </span>
+                  <span style={{ flex: 1, fontSize: '0.78rem', fontWeight: 600, color: 'var(--on-surface)' }}>Run outcome</span>
+                  <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--outline)' }}>
+                    {open.pipeline ? 'expand_less' : 'expand_more'}
+                  </span>
+                </button>
+                {open.pipeline !== false && (
+                  <div style={{ padding: '10px 12px', fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                    {pipelineEvents.map((ev, i) => {
+                      const cfg = EVENT_CONFIG[ev.type] || { color: 'var(--outline)', icon: 'info' };
+                      return (
+                        <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: '6px', color: cfg.color }}>
+                          <span className="material-symbols-outlined" style={{ fontSize: '14px', flexShrink: 0, fontVariationSettings: "'FILL' 1" }}>
+                            {cfg.icon}
+                          </span>
+                          <span style={{ wordBreak: 'break-word' }}>{ev.message || ev.type}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          }
+
+          const list = groups[agentId] || [];
+          if (list.length === 0) return null;
+
+          const meta = AGENT_PROFILES.find((a) => a.id === agentId);
+          const summary = summarizeAgentEvents(agentId, list);
+          const dur = durationForAgent(agentId);
+          const isOpen = open[agentId] !== false;
+
+          return (
+            <div
+              key={agentId}
+              style={{
+                borderRadius: '10px',
+                border: `1px solid var(--outline-variant)`,
+                background: 'var(--surface-container-lowest)',
+                overflow: 'hidden',
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => setOpen((o) => ({ ...o, [agentId]: !o[agentId] }))}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '10px',
+                  border: 'none',
+                  background: 'var(--surface-container)',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                }}
+              >
+                <span className="material-symbols-outlined" style={{ fontSize: '22px', color: meta?.color || 'var(--secondary)', flexShrink: 0 }}>
+                  {meta?.icon || 'smart_toy'}
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--on-surface)' }}>{meta?.name || agentId}</span>
+                    <span style={{ fontSize: '0.65rem', color: 'var(--outline)', padding: '2px 8px', background: 'var(--surface-container-lowest)', borderRadius: '999px' }}>
+                      {list.length} events
+                    </span>
+                    {dur && (
+                      <span style={{ fontSize: '0.65rem', color: 'var(--outline)' }}>{dur}</span>
+                    )}
+                  </div>
+                  {summary && (
+                    <div style={{ fontSize: '0.7rem', color: 'var(--on-surface-variant)', marginTop: '4px' }}>{summary}</div>
+                  )}
+                </div>
+                <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--outline)', flexShrink: 0 }}>
+                  {isOpen ? 'expand_less' : 'expand_more'}
+                </span>
+              </button>
+              {isOpen && (
+                <div style={{ padding: '10px 12px', fontFamily: 'monospace', fontSize: '0.75rem', maxHeight: '240px', overflowY: 'auto' }}>
+                  {list.map((ev, i) => {
+                    const cfg = EVENT_CONFIG[ev.type] || { color: 'var(--outline)', icon: 'info' };
+                    const screenshotSrc = ev.screenshot_file ? `/screenshots/${ev.screenshot_file}` : null;
+                    return (
+                      <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '8px', color: cfg.color }}>
+                        <span className="material-symbols-outlined" style={{ fontSize: '14px', flexShrink: 0, marginTop: '2px', fontVariationSettings: "'FILL' 1" }}>
+                          {cfg.icon}
+                        </span>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <span style={{ lineHeight: 1.4, wordBreak: 'break-word' }}>{ev.message || ev.type}</span>
+                          {screenshotSrc && (
+                            <div style={{ marginTop: '5px' }}>
+                              <img
+                                src={screenshotSrc}
+                                alt={ev.message || ''}
+                                onClick={() => setLightbox({ src: screenshotSrc, label: ev.message })}
+                                style={{
+                                  height: '64px',
+                                  borderRadius: '5px',
+                                  border: '1px solid rgba(197,198,207,0.4)',
+                                  objectFit: 'cover',
+                                  cursor: 'zoom-in',
+                                  display: 'block',
+                                }}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {lightbox && <Lightbox src={lightbox.src} label={lightbox.label} onClose={() => setLightbox(null)} />}
+    </div>
+  );
+}
+
+export default AgentActivityLog;

--- a/frontend/src/components/AgentPipelineTracker.jsx
+++ b/frontend/src/components/AgentPipelineTracker.jsx
@@ -1,0 +1,250 @@
+import React, { useMemo } from 'react';
+import { AGENT_PROFILES, PIPELINE_AGENT_IDS } from '../data/agentProfiles.js';
+
+/**
+ * Derive per-agent pipeline state from live SSE events.
+ * Events may include clientTs (injected client-side) for duration.
+ *
+ * @param {Array<Record<string, unknown>>} events
+ * @param {string | undefined} runStatus
+ */
+function computePipelineState(events, runStatus) {
+  /** @type {Record<string, 'pending' | 'active' | 'completed'>} */
+  const status = Object.fromEntries(PIPELINE_AGENT_IDS.map((id) => [id, 'pending']));
+  /** @type {Record<string, number | null>} */
+  const startTs = Object.fromEntries(PIPELINE_AGENT_IDS.map((id) => [id, null]));
+  /** @type {Record<string, number | null>} */
+  const endTs = Object.fromEntries(PIPELINE_AGENT_IDS.map((id) => [id, null]));
+
+  for (const ev of events) {
+    const ts =
+      typeof ev.clientTs === 'number'
+        ? ev.clientTs
+        : typeof ev.ts === 'number'
+          ? ev.ts
+          : null;
+
+    if (ev.type === 'agent_start' && ev.agent && PIPELINE_AGENT_IDS.includes(String(ev.agent))) {
+      const id = String(ev.agent);
+      status[id] = 'active';
+      if (ts != null) startTs[id] = ts;
+    } else if (ev.type === 'agent_done' && ev.agent && PIPELINE_AGENT_IDS.includes(String(ev.agent))) {
+      const id = String(ev.agent);
+      status[id] = 'completed';
+      if (ts != null) endTs[id] = ts;
+    }
+  }
+
+  // Successful completion: reporter finishes — nothing left running
+  if (runStatus === 'completed') {
+    PIPELINE_AGENT_IDS.forEach((id) => {
+      if (status[id] === 'active') status[id] = 'completed';
+    });
+  }
+
+  return { status, startTs, endTs };
+}
+
+function formatDurationMs(ms) {
+  if (ms == null || Number.isNaN(ms) || ms < 0) return null;
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+}
+
+/**
+ * @param {object} props
+ * @param {Array<Record<string, unknown>>} [props.events]
+ * @param {string} [props.runStatus]
+ * @param {'run' | 'overview'} [props.variant]
+ */
+export function AgentPipelineTracker({ events = [], runStatus, variant = 'run' }) {
+  const { status, startTs, endTs } = useMemo(
+    () => computePipelineState(events, runStatus),
+    [events, runStatus]
+  );
+
+  const STAGGER_MS = 70;
+
+  if (variant === 'overview') {
+    return (
+      <div
+        role="img"
+        aria-label="Agent pipeline order"
+        className="agent-pipeline"
+        style={{
+          display: 'flex',
+          alignItems: 'stretch',
+          justifyContent: 'space-between',
+          gap: '8px',
+          flexWrap: 'wrap',
+          padding: '12px 0',
+        }}
+      >
+        {AGENT_PROFILES.map((agent, i) => (
+          <React.Fragment key={agent.id}>
+            <div
+              className="agent-pipeline-overview__card"
+              style={{
+                animationDelay: `${i * STAGGER_MS}ms`,
+                flex: '1 1 120px',
+                minWidth: '100px',
+                maxWidth: '160px',
+                padding: '10px 8px',
+                borderRadius: '10px',
+                border: `1px solid var(--outline-variant)`,
+                background: 'var(--surface-container-lowest)',
+                textAlign: 'center',
+              }}
+            >
+              <span
+                className="material-symbols-outlined agent-pipeline-overview__icon"
+                style={{ fontSize: '22px', color: agent.color, display: 'block', marginBottom: '6px' }}
+              >
+                {agent.icon}
+              </span>
+              <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface)', lineHeight: 1.2 }}>
+                {agent.name}
+              </div>
+              <div style={{ fontSize: '0.65rem', color: 'var(--outline)', marginTop: '4px' }}>Step {agent.pipelinePosition}</div>
+            </div>
+            {i < AGENT_PROFILES.length - 1 && (
+              <div
+                style={{
+                  alignSelf: 'center',
+                  color: 'var(--outline)',
+                  fontSize: '18px',
+                  flex: '0 0 auto',
+                }}
+                aria-hidden
+              >
+                <span className="material-symbols-outlined" style={{ fontSize: '20px' }}>
+                  arrow_forward
+                </span>
+              </div>
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        marginBottom: '12px',
+        padding: '12px 14px',
+        background: 'var(--surface-container-lowest)',
+        borderRadius: '10px',
+        border: '1px solid var(--outline-variant)',
+      }}
+    >
+      <div style={{ fontSize: '0.65rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '10px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <span className="material-symbols-outlined" style={{ fontSize: '14px', color: 'var(--secondary)' }}>
+          account_tree
+        </span>
+        Agent pipeline
+      </div>
+      <div
+        className="agent-pipeline"
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: '6px',
+          flexWrap: 'wrap',
+        }}
+      >
+        {AGENT_PROFILES.map((agent, i) => {
+          const st = status[agent.id] || 'pending';
+          const dur =
+            startTs[agent.id] != null && endTs[agent.id] != null
+              ? formatDurationMs(endTs[agent.id] - startTs[agent.id])
+              : null;
+
+          const isActive = st === 'active';
+          const isDone = st === 'completed';
+          const nextAgent = i < AGENT_PROFILES.length - 1 ? AGENT_PROFILES[i + 1] : null;
+          const connectorFlow =
+            nextAgent &&
+            (status[agent.id] === 'completed' || status[nextAgent.id] === 'active');
+
+          return (
+            <React.Fragment key={agent.id}>
+              <div
+                className="agent-pipeline__step"
+                style={{
+                  animationDelay: `${i * STAGGER_MS}ms`,
+                  flex: '1 1 88px',
+                  minWidth: '72px',
+                  maxWidth: '120px',
+                  textAlign: 'center',
+                }}
+              >
+                <div
+                  className={`agent-pipeline__glyph${isActive ? ' agent-pipeline__glyph--active' : ''}${isDone ? ' agent-pipeline__glyph--done' : ''}`}
+                  style={{
+                    width: '36px',
+                    height: '36px',
+                    margin: '0 auto 6px',
+                    borderRadius: '50%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: isDone
+                      ? '#dcfce7'
+                      : isActive
+                        ? 'var(--secondary-soft)'
+                        : 'var(--surface-container-high)',
+                    border: `2px solid ${
+                      isDone ? '#16a34a' : isActive ? 'var(--secondary)' : 'var(--outline-variant)'
+                    }`,
+                  }}
+                >
+                  {isDone ? (
+                    <span className="material-symbols-outlined" style={{ fontSize: '20px', color: '#16a34a', fontVariationSettings: "'FILL' 1" }}>
+                      check
+                    </span>
+                  ) : isActive ? (
+                    <span className="material-symbols-outlined" style={{ fontSize: '20px', color: 'var(--secondary)', fontVariationSettings: "'FILL' 1" }}>
+                      progress_activity
+                    </span>
+                  ) : (
+                    <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--outline)' }}>
+                      radio_button_unchecked
+                    </span>
+                  )}
+                </div>
+                <div style={{ fontSize: '0.65rem', fontWeight: 600, color: 'var(--on-surface)', lineHeight: 1.15 }}>
+                  {agent.name}
+                </div>
+                {dur && (
+                  <div style={{ fontSize: '0.6rem', color: 'var(--outline)', marginTop: '2px' }}>{dur}</div>
+                )}
+              </div>
+              {i < AGENT_PROFILES.length - 1 && (
+                <div
+                  className={`agent-pipeline__connector${connectorFlow ? ' agent-pipeline__connector--flow' : ''}`}
+                  style={{
+                    alignSelf: 'center',
+                    marginTop: '-8px',
+                    color: connectorFlow ? undefined : 'var(--outline-variant)',
+                    opacity: connectorFlow ? 1 : 0.85,
+                  }}
+                  aria-hidden
+                >
+                  <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>
+                    chevron_right
+                  </span>
+                </div>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default AgentPipelineTracker;

--- a/frontend/src/components/AgentProfiles.jsx
+++ b/frontend/src/components/AgentProfiles.jsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { AGENT_PROFILES } from '../data/agentProfiles.js';
+import { AgentPipelineTracker } from './AgentPipelineTracker.jsx';
+
+export default function AgentProfiles() {
+  return (
+    <div>
+      <div style={{ marginBottom: '1.75rem' }}>
+        <span
+          style={{
+            display: 'block',
+            fontSize: '11px',
+            fontWeight: 700,
+            color: 'var(--on-tertiary-container)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.2em',
+            marginBottom: '8px',
+          }}
+        >
+          Platform
+        </span>
+        <h2
+          style={{
+            fontSize: '2.25rem',
+            fontWeight: 300,
+            letterSpacing: '-0.02em',
+            color: 'var(--primary)',
+            marginBottom: '8px',
+          }}
+        >
+          AI Agent Team
+        </h2>
+        <p style={{ fontSize: '0.95rem', color: 'var(--on-surface-variant)', maxWidth: '720px', lineHeight: 1.55 }}>
+          BugHunter.AI runs a fixed multi-agent pipeline powered by LangGraph: each specialist handles one stage—from
+          strategy and browser exploration to validation, security probes, and structured reporting. Events stream to
+          your test run in real time.
+        </p>
+      </div>
+
+      <div
+        className="glass-card"
+        style={{
+          marginBottom: '1.5rem',
+          borderRadius: '12px',
+          padding: '1rem 1.25rem',
+          border: '1px solid var(--outline-variant)',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '0.7rem',
+            fontWeight: 700,
+            color: 'var(--on-surface-variant)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            marginBottom: '4px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+          }}
+        >
+          <span className="material-symbols-outlined" style={{ fontSize: '16px', color: 'var(--secondary)' }}>
+            linear_scale
+          </span>
+          Execution order
+        </div>
+        <AgentPipelineTracker variant="overview" />
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+          gap: '1.25rem',
+        }}
+      >
+        {AGENT_PROFILES.map((agent) => (
+          <div
+            key={agent.id}
+            className="glass-card hoverable-card"
+            style={{
+              borderRadius: '12px',
+              padding: '1.25rem 1.35rem',
+              border: '1px solid var(--outline-variant)',
+              borderLeft: `4px solid ${agent.color}`,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '10px',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
+              <div
+                style={{
+                  width: '44px',
+                  height: '44px',
+                  borderRadius: '10px',
+                  background: 'var(--surface-container-high)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                }}
+              >
+                <span className="material-symbols-outlined" style={{ fontSize: '26px', color: agent.color }}>
+                  {agent.icon}
+                </span>
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: '0.65rem', fontWeight: 700, color: 'var(--outline)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                  Step {agent.pipelinePosition}
+                </div>
+                <div style={{ fontSize: '1.1rem', fontWeight: 700, color: 'var(--on-surface)', letterSpacing: '-0.02em' }}>
+                  {agent.name}
+                </div>
+                <div style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--secondary)', marginTop: '2px' }}>{agent.role}</div>
+              </div>
+            </div>
+            <p style={{ fontSize: '0.85rem', color: 'var(--on-surface-variant)', lineHeight: 1.5, margin: 0 }}>{agent.description}</p>
+            <div>
+              <div style={{ fontSize: '0.65rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '6px' }}>
+                Capabilities
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                {agent.capabilities.map((c) => (
+                  <span
+                    key={c}
+                    style={{
+                      fontSize: '0.72rem',
+                      padding: '4px 10px',
+                      borderRadius: '999px',
+                      background: 'var(--surface-container-high)',
+                      color: 'var(--on-surface)',
+                      border: '1px solid var(--outline-variant)',
+                    }}
+                  >
+                    {c}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div>
+              <div style={{ fontSize: '0.65rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '6px' }}>
+                Tools
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                {agent.tools.map((t) => (
+                  <span
+                    key={t}
+                    style={{
+                      fontSize: '0.72rem',
+                      padding: '4px 10px',
+                      borderRadius: '8px',
+                      background: 'var(--secondary-soft)',
+                      color: 'var(--secondary)',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ApiTesting.jsx
+++ b/frontend/src/components/ApiTesting.jsx
@@ -215,8 +215,8 @@ export default function ApiTesting() {
     <div>
       {/* Header */}
       <div style={{ marginBottom: '2rem' }}>
-        <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-tertiary-container)', textTransform: 'uppercase', letterSpacing: '0.2em', marginBottom: '6px' }}>AI-Powered Testing</span>
-        <h2 style={{ fontSize: '2.25rem', fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--primary)', marginBottom: '6px' }}>API Testing</h2>
+        <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.14em', marginBottom: '6px' }}>AI-powered testing</span>
+        <h1 style={{ fontSize: '1.75rem', fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--primary)', marginBottom: '6px' }}>API testing</h1>
         <p style={{ color: 'var(--on-surface-variant)', fontSize: '0.875rem' }}>Upload an OpenAPI/Swagger spec — the AI generates and executes test cases per endpoint.</p>
       </div>
 
@@ -228,9 +228,9 @@ export default function ApiTesting() {
       )}
 
       {/* Step 1: Upload spec */}
-      <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '12px', padding: '1.5rem', marginBottom: '1.5rem', border: '1px solid var(--outline-variant)' }}>
+      <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', padding: '1.5rem', marginBottom: '1.5rem', border: '1px solid var(--border-subtle)' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '1rem' }}>
-          <span style={{ width: '24px', height: '24px', borderRadius: '50%', background: 'var(--primary)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', fontWeight: 700, flexShrink: 0 }}>1</span>
+          <span style={{ width: '24px', height: '24px', borderRadius: '50%', background: 'var(--primary-button)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', fontWeight: 700, flexShrink: 0 }}>1</span>
           <span style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--on-surface)' }}>Upload or paste your OpenAPI spec (JSON)</span>
         </div>
 
@@ -259,32 +259,36 @@ export default function ApiTesting() {
             style={{ flex: 1, padding: '9px 12px', borderRadius: '8px', border: '1px solid var(--outline-variant)', background: 'var(--surface-container-low)', color: 'var(--on-surface)', fontSize: '0.85rem' }}
           />
           <button
+            type="button"
             onClick={handleParseSpec}
             disabled={!specText.trim() || parsing}
-            style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '9px 20px', borderRadius: '8px', background: 'var(--secondary)', color: '#fff', border: 'none', fontSize: '0.85rem', fontWeight: 600, cursor: !specText.trim() || parsing ? 'not-allowed' : 'pointer', opacity: !specText.trim() || parsing ? 0.6 : 1 }}
+            className="btn-primary"
+            style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '9px 20px', fontSize: '0.85rem', fontWeight: 600, cursor: !specText.trim() || parsing ? 'not-allowed' : 'pointer', opacity: !specText.trim() || parsing ? 0.6 : 1 }}
           >
             <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>document_scanner</span>
-            {parsing ? 'Parsing…' : 'Parse Spec'}
+            {parsing ? 'Parsing…' : 'Parse spec'}
           </button>
         </div>
       </div>
 
       {/* Step 2: Endpoint list */}
       {parsedSpec && (
-        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '12px', overflow: 'hidden', marginBottom: '1.5rem', border: '1px solid var(--outline-variant)' }}>
-          <div style={{ padding: '1rem 1.5rem', borderBottom: '1px solid var(--outline-variant)', display: 'flex', alignItems: 'center', gap: '12px' }}>
-            <span style={{ width: '24px', height: '24px', borderRadius: '50%', background: 'var(--primary)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', fontWeight: 700, flexShrink: 0 }}>2</span>
+        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', overflow: 'hidden', marginBottom: '1.5rem', border: '1px solid var(--border-subtle)' }}>
+          <div style={{ padding: '1rem 1.5rem', borderBottom: '1px solid var(--border-subtle)', display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <span style={{ width: '24px', height: '24px', borderRadius: '50%', background: 'var(--primary-button)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', fontWeight: 700, flexShrink: 0 }}>2</span>
             <div style={{ flex: 1 }}>
               <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--on-surface)' }}>{parsedSpec.spec_info?.title}</div>
               <div style={{ fontSize: '0.75rem', color: 'var(--outline)' }}>{parsedSpec.endpoints?.length} endpoint{parsedSpec.endpoints?.length !== 1 ? 's' : ''} detected{parsedSpec.spec_info?.version ? ` · v${parsedSpec.spec_info.version}` : ''}</div>
             </div>
             <button
+              type="button"
               onClick={handleRunTests}
               disabled={running}
-              style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 20px', borderRadius: '8px', background: running ? 'var(--outline)' : 'var(--primary)', color: '#fff', border: 'none', fontSize: '0.85rem', fontWeight: 600, cursor: running ? 'wait' : 'pointer' }}
+              className="btn-primary"
+              style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 20px', fontSize: '0.85rem', fontWeight: 600, cursor: running ? 'wait' : 'pointer', background: running ? 'var(--outline)' : undefined }}
             >
               <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>play_arrow</span>
-              {running ? 'Running…' : 'Run Tests'}
+              {running ? 'Running…' : 'Run tests'}
             </button>
           </div>
           <div style={{ maxHeight: '300px', overflowY: 'auto' }}>

--- a/frontend/src/components/AppFooter.jsx
+++ b/frontend/src/components/AppFooter.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function AppFooter() {
+  return (
+    <footer className="app-footer">
+      <span>© {new Date().getFullYear()} BugHunter.AI. All rights reserved.</span>
+      <nav className="app-footer__links" aria-label="Legal">
+        <a href="#" className="footer-link">Cookie policy</a>
+        <a href="#" className="footer-link">Terms of use</a>
+        <a href="#" className="footer-link">Privacy</a>
+      </nav>
+    </footer>
+  );
+}

--- a/frontend/src/components/AppHeader.jsx
+++ b/frontend/src/components/AppHeader.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+import { useSidebar } from '../context/SidebarContext.jsx';
+
+export default function AppHeader() {
+  const { user } = useAuth();
+  const { collapsed, toggle } = useSidebar();
+  const initials = (user?.name || user?.email || 'U')
+    .split(/\s+/)
+    .map((s) => s[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <header className="app-header">
+      <div className="app-header__left">
+        <button
+          type="button"
+          className="app-header__icon-btn"
+          aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+          aria-expanded={!collapsed}
+          onClick={toggle}
+        >
+          <span className="material-symbols-outlined" style={{ fontSize: '22px' }}>menu</span>
+        </button>
+        <div className="app-header__brand">
+          <span className="app-header__brand-title">BugHunter.AI</span>
+          <span className="app-header__brand-sub">Enterprise audit</span>
+        </div>
+      </div>
+      <div className="app-header__right">
+        <button type="button" className="app-header__icon-btn" aria-label="Help">
+          <span className="material-symbols-outlined" style={{ fontSize: '22px' }}>help</span>
+        </button>
+        <Link
+          to="/profile"
+          className="app-header__user"
+          title="Profile and account settings"
+          aria-label="Open profile"
+        >
+          <div className="app-header__avatar">{initials}</div>
+          <span className="material-symbols-outlined app-header__chevron" style={{ fontSize: '18px' }}>expand_more</span>
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/AppList.jsx
+++ b/frontend/src/components/AppList.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import api from '../services/api.js';
+import NewRunModal from './NewRunModal.jsx';
 
 const EMPTY_STEP = { action: 'fill', selector: '', value: '', timeout: 15000 };
 
@@ -74,12 +75,19 @@ function AppModal({ app, onClose, onSave }) {
   const [form, setForm] = useState({ name: app?.name || '', url: app?.url || '', username: existingCreds.username || '', password: existingCreds.password || '' });
   const [authMode, setAuthMode] = useState(hasLoginFlow ? 'sso' : existingCreds.username || existingCreds.password ? 'simple' : 'none');
   const [loginSteps, setLoginSteps] = useState(hasLoginFlow ? existingCreds.login_flow : []);
+  const [blockedDomains, setBlockedDomains] = useState((existingCreds.blocked_domains || []).join('\n'));
+  const [showAdvanced, setShowAdvanced] = useState((existingCreds.blocked_domains || []).length > 0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault(); setLoading(true); setError('');
     try {
+      const parsedBlockedDomains = blockedDomains
+        .split(/[\n,]+/)
+        .map(d => d.trim().toLowerCase())
+        .filter(Boolean);
+
       let credentials;
       if (authMode === 'simple' && (form.username || form.password)) {
         credentials = { username: form.username, password: form.password };
@@ -92,6 +100,9 @@ function AppModal({ app, onClose, onSave }) {
           return s;
         });
         credentials = { login_flow: cleanedSteps };
+      }
+      if (parsedBlockedDomains.length > 0) {
+        credentials = { ...(credentials || {}), blocked_domains: parsedBlockedDomains };
       }
       const payload = { name: form.name, url: form.url, credentials };
       if (app) await api.put(`/apps/${app.id}`, payload);
@@ -130,7 +141,7 @@ function AppModal({ app, onClose, onSave }) {
                 <button key={opt.value} type="button" onClick={() => setAuthMode(opt.value)} style={{
                   flex: 1, padding: '9px 6px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 500,
                   border: authMode === opt.value ? '2px solid var(--secondary)' : '1px solid var(--outline-variant)',
-                  background: authMode === opt.value ? 'rgba(0,88,190,0.06)' : 'transparent',
+                  background: authMode === opt.value ? 'var(--secondary-soft)' : 'transparent',
                   color: authMode === opt.value ? 'var(--secondary)' : 'var(--on-surface-variant)',
                 }}>{opt.label}</button>
               ))}
@@ -163,13 +174,248 @@ function AppModal({ app, onClose, onSave }) {
             </div>
           )}
 
+          {/* Advanced — blocked domains */}
+          <div style={{ border: '1px solid var(--outline-variant)', borderRadius: '10px', overflow: 'hidden' }}>
+            <button type="button" onClick={() => setShowAdvanced(v => !v)}
+              style={{ width: '100%', padding: '10px 14px', background: 'var(--surface-container-low)', border: 'none', display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', color: 'var(--on-surface-variant)', fontSize: '0.8rem', fontWeight: 600 }}>
+              <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>tune</span>
+              <span style={{ flex: 1, textAlign: 'left' }}>Advanced</span>
+              <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>{showAdvanced ? 'expand_less' : 'expand_more'}</span>
+            </button>
+            {showAdvanced && (
+              <div style={{ padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                <label style={labelStyle}>
+                  Block domains (one per line or comma-separated)
+                </label>
+                <p style={{ fontSize: '0.72rem', color: 'var(--outline)', marginBottom: '4px', lineHeight: 1.5 }}>
+                  Requests to these domains will be blocked during the test run. Useful for preventing consent banners (e.g. <code>trustarc.com</code>, <code>onetrust.com</code>) from loading.
+                  Common CDNs are already blocked by default.
+                </p>
+                <textarea
+                  value={blockedDomains}
+                  onChange={e => setBlockedDomains(e.target.value)}
+                  rows={3}
+                  placeholder={'example.com\nanalytics.io'}
+                  className="ent-input"
+                  style={{ ...inputStyle, fontFamily: 'monospace', fontSize: '0.8rem', resize: 'vertical' }}
+                />
+              </div>
+            )}
+          </div>
+
           <div style={{ display: 'flex', gap: '10px', marginTop: '8px' }}>
             <button type="button" onClick={onClose} style={{ flex: 1, padding: '12px', border: '1px solid var(--outline-variant)', borderRadius: '8px', background: 'transparent', color: 'var(--on-surface)', fontSize: '0.875rem', fontWeight: 500 }}>Cancel</button>
-            <button type="submit" disabled={loading} style={{ flex: 1, padding: '12px', background: 'linear-gradient(135deg, var(--primary), var(--primary-container))', color: '#fff', border: 'none', borderRadius: '8px', fontSize: '0.875rem', fontWeight: 600, opacity: loading ? 0.7 : 1 }}>
+            <button type="submit" disabled={loading} className="btn-primary" style={{ flex: 1, padding: '12px', fontSize: '0.875rem', fontWeight: 600, opacity: loading ? 0.7 : 1 }}>
               {loading ? 'Saving...' : 'Save Application'}
             </button>
           </div>
         </form>
+      </div>
+    </div>
+  );
+}
+
+const SEVERITY_COLOR = { critical: '#b91c1c', high: '#c2410c', medium: '#b45309', low: '#15803d', info: '#0369a1' };
+const SEVERITY_BG = { critical: 'rgba(185,28,28,0.08)', high: 'rgba(194,65,12,0.08)', medium: 'rgba(180,83,9,0.08)', low: 'rgba(21,128,61,0.08)', info: 'rgba(3,105,161,0.08)' };
+
+function MemoryModal({ app, onClose }) {
+  const [memory, setMemory] = useState(null);
+  const [updatedAt, setUpdatedAt] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [clearing, setClearing] = useState(false);
+  const [tab, setTab] = useState('overview');
+
+  useEffect(() => {
+    api.get(`/apps/${app.id}/memory`)
+      .then(res => { setMemory(res.data.data); setUpdatedAt(res.data.updated_at); })
+      .catch(() => setError('Failed to load memory'))
+      .finally(() => setLoading(false));
+  }, [app.id]);
+
+  const handleClear = async () => {
+    if (!window.confirm('Clear all agent memory for this app? The next run will start fresh.')) return;
+    setClearing(true);
+    try {
+      await api.delete(`/apps/${app.id}/memory`);
+      setMemory(null);
+    } catch {
+      setError('Failed to clear memory');
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  const tabs = ['overview', 'login', 'pages', 'known bugs'];
+
+  return (
+    <div style={{ position: 'fixed', inset: 0, background: 'rgba(25,28,30,0.35)', backdropFilter: 'blur(4px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50, padding: '1rem' }}>
+      <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '14px', width: '100%', maxWidth: '680px', maxHeight: '88vh', display: 'flex', flexDirection: 'column', boxShadow: '0 8px 40px rgba(25,28,30,0.15)' }}>
+        {/* Header */}
+        <div style={{ padding: '1.5rem 1.75rem 1rem', borderBottom: '1px solid var(--border-subtle)', flexShrink: 0 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
+                <span className="material-symbols-outlined" style={{ color: 'var(--secondary)', fontSize: '20px' }}>psychology</span>
+                <h2 style={{ fontSize: '1.1rem', fontWeight: 700, color: 'var(--primary)', letterSpacing: '-0.01em' }}>Agent Memory</h2>
+              </div>
+              <p style={{ fontSize: '0.8rem', color: 'var(--on-surface-variant)' }}>{app.name}</p>
+            </div>
+            <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+              {memory && (
+                <button onClick={handleClear} disabled={clearing} style={{ padding: '6px 12px', border: '1px solid var(--error)', borderRadius: '8px', background: 'transparent', color: 'var(--error)', fontSize: '0.78rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '4px' }}>
+                  <span className="material-symbols-outlined" style={{ fontSize: '15px' }}>delete_sweep</span>
+                  {clearing ? 'Clearing…' : 'Clear Memory'}
+                </button>
+              )}
+              <button onClick={onClose} style={{ padding: '6px', background: 'none', border: 'none', color: 'var(--on-surface-variant)', lineHeight: 1 }}>
+                <span className="material-symbols-outlined" style={{ fontSize: '20px' }}>close</span>
+              </button>
+            </div>
+          </div>
+          {/* Tabs */}
+          {memory && (
+            <div style={{ display: 'flex', gap: '4px', marginTop: '1rem' }}>
+              {tabs.map(t => (
+                <button key={t} onClick={() => setTab(t)} style={{ padding: '6px 14px', borderRadius: '8px', border: 'none', background: tab === t ? 'var(--secondary-soft)' : 'transparent', color: tab === t ? 'var(--secondary)' : 'var(--on-surface-variant)', fontSize: '0.8rem', fontWeight: tab === t ? 700 : 400, textTransform: 'capitalize' }}>
+                  {t}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Body */}
+        <div style={{ overflowY: 'auto', padding: '1.25rem 1.75rem', flex: 1 }}>
+          {error && <div style={{ color: 'var(--error)', fontSize: '0.875rem', padding: '10px', background: 'var(--error-container)', borderRadius: '8px' }}>{error}</div>}
+          {loading && <div style={{ color: 'var(--on-surface-variant)', fontSize: '0.875rem', display: 'flex', gap: '8px', alignItems: 'center' }}><span className="material-symbols-outlined pulse" style={{ color: 'var(--secondary)' }}>autorenew</span> Loading memory…</div>}
+
+          {!loading && !memory && !error && (
+            <div style={{ textAlign: 'center', padding: '3rem 0', color: 'var(--on-surface-variant)' }}>
+              <span className="material-symbols-outlined" style={{ fontSize: '48px', color: 'var(--outline-variant)', display: 'block', marginBottom: '1rem' }}>psychology</span>
+              <p style={{ fontWeight: 500, color: 'var(--on-surface)', marginBottom: '4px' }}>No memory yet</p>
+              <p style={{ fontSize: '0.85rem' }}>Memory is built automatically after the first completed test run.</p>
+            </div>
+          )}
+
+          {memory && tab === 'overview' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '12px' }}>
+                {[
+                  { label: 'Total Runs', value: memory.total_runs ?? 0, icon: 'play_circle' },
+                  { label: 'Pages Tracked', value: Object.keys(memory.pages || {}).length, icon: 'article' },
+                  { label: 'Known Bugs', value: (memory.known_bugs || []).length, icon: 'bug_report' },
+                ].map(stat => (
+                  <div key={stat.label} style={{ background: 'var(--surface-container-low)', borderRadius: '10px', padding: '16px', display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    <span className="material-symbols-outlined" style={{ color: 'var(--secondary)', fontSize: '20px' }}>{stat.icon}</span>
+                    <span style={{ fontSize: '1.5rem', fontWeight: 700, color: 'var(--on-surface)', lineHeight: 1 }}>{stat.value}</span>
+                    <span style={{ fontSize: '0.72rem', color: 'var(--on-surface-variant)', textTransform: 'uppercase', fontWeight: 600, letterSpacing: '0.06em' }}>{stat.label}</span>
+                  </div>
+                ))}
+              </div>
+              {updatedAt && (
+                <p style={{ fontSize: '0.78rem', color: 'var(--outline)', marginTop: '4px' }}>
+                  Last updated: {new Date(updatedAt).toLocaleString()}
+                </p>
+              )}
+              {memory.last_run_id && (
+                <p style={{ fontSize: '0.78rem', color: 'var(--outline)' }}>
+                  Last run ID: <code style={{ fontFamily: 'monospace' }}>{memory.last_run_id}</code>
+                </p>
+              )}
+            </div>
+          )}
+
+          {memory && tab === 'login' && (
+            <div>
+              {!memory.login?.working_steps ? (
+                <div style={{ color: 'var(--on-surface-variant)', fontSize: '0.875rem', padding: '2rem 0', textAlign: 'center' }}>
+                  <span className="material-symbols-outlined" style={{ fontSize: '36px', color: 'var(--outline-variant)', display: 'block', marginBottom: '8px' }}>lock_open</span>
+                  No stored login flow yet. The agent will use smart login on the next run and store the working steps.
+                </div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                  <div style={{ display: 'flex', gap: '16px', fontSize: '0.8rem', color: 'var(--on-surface-variant)', marginBottom: '4px' }}>
+                    <span>Failure count: <strong style={{ color: (memory.login.failure_count || 0) > 0 ? 'var(--error)' : 'var(--on-surface)' }}>{memory.login.failure_count || 0}</strong></span>
+                    {memory.login.last_success_run_id && <span>Last success: <code style={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>{memory.login.last_success_run_id}</code></span>}
+                  </div>
+                  {memory.login.working_steps.map((step, i) => (
+                    <div key={i} style={{ display: 'flex', gap: '10px', alignItems: 'flex-start', background: 'var(--surface-container-low)', borderRadius: '8px', padding: '10px 12px' }}>
+                      <span style={{ flex: '0 0 auto', fontSize: '0.72rem', fontWeight: 700, color: 'var(--outline)', minWidth: '18px', marginTop: '2px' }}>{i + 1}</span>
+                      <div style={{ flex: 1, fontSize: '0.82rem' }}>
+                        <span style={{ fontWeight: 600, color: 'var(--secondary)', textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: '0.05em' }}>{step.action}</span>
+                        {step.selector && <div style={{ fontFamily: 'monospace', fontSize: '0.78rem', color: 'var(--on-surface-variant)', marginTop: '2px' }}>{step.selector}</div>}
+                        {step.value && (
+                          <div style={{ marginTop: '2px', color: step.value === '__PASSWORD__' ? 'var(--outline)' : 'var(--on-surface)', fontStyle: step.value === '__PASSWORD__' ? 'italic' : 'normal' }}>
+                            {step.value === '__PASSWORD__' ? '••••••••' : step.value === '__EMAIL__' ? '[email]' : step.value}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {memory && tab === 'pages' && (
+            <div>
+              {Object.keys(memory.pages || {}).length === 0 ? (
+                <div style={{ color: 'var(--on-surface-variant)', fontSize: '0.875rem', padding: '2rem 0', textAlign: 'center' }}>
+                  <span className="material-symbols-outlined" style={{ fontSize: '36px', color: 'var(--outline-variant)', display: 'block', marginBottom: '8px' }}>article</span>
+                  No pages tracked yet.
+                </div>
+              ) : (
+                <div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 80px 90px', gap: '0', fontSize: '10px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.1em', padding: '6px 12px', marginBottom: '4px' }}>
+                    <span>Page URL</span><span style={{ textAlign: 'center' }}>Bugs</span><span style={{ textAlign: 'center' }}>Priority</span>
+                  </div>
+                  {Object.entries(memory.pages)
+                    .sort(([, a], [, b]) => (b.priority_score || 0) - (a.priority_score || 0))
+                    .map(([url, info]) => (
+                      <div key={url} style={{ display: 'grid', gridTemplateColumns: '1fr 80px 90px', alignItems: 'center', padding: '10px 12px', background: 'var(--surface-container-low)', borderRadius: '8px', marginBottom: '6px', gap: '8px' }}>
+                        <a href={url} target="_blank" rel="noopener noreferrer" style={{ fontFamily: 'monospace', fontSize: '0.75rem', color: 'var(--link)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={url}>{url}</a>
+                        <span style={{ textAlign: 'center', fontWeight: 700, color: (info.bug_count || 0) > 2 ? 'var(--error)' : 'var(--on-surface)' }}>{info.bug_count || 0}</span>
+                        <span style={{ textAlign: 'center', fontSize: '0.8rem', color: 'var(--secondary)', fontWeight: 600 }}>{info.priority_score || 0}</span>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {memory && tab === 'known bugs' && (
+            <div>
+              {(memory.known_bugs || []).length === 0 ? (
+                <div style={{ color: 'var(--on-surface-variant)', fontSize: '0.875rem', padding: '2rem 0', textAlign: 'center' }}>
+                  <span className="material-symbols-outlined" style={{ fontSize: '36px', color: 'var(--outline-variant)', display: 'block', marginBottom: '8px' }}>bug_report</span>
+                  No known bugs in memory yet.
+                </div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  {[...memory.known_bugs]
+                    .sort((a, b) => (b.occurrence_count || 1) - (a.occurrence_count || 1))
+                    .map((bug, i) => (
+                      <div key={i} style={{ background: 'var(--surface-container-low)', borderRadius: '10px', padding: '12px 14px', borderLeft: `3px solid ${SEVERITY_COLOR[bug.severity] || 'var(--outline)'}` }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px', marginBottom: '6px' }}>
+                          <span style={{ fontWeight: 600, fontSize: '0.85rem', color: 'var(--on-surface)', flex: 1 }}>{bug.title}</span>
+                          <div style={{ display: 'flex', gap: '6px', flexShrink: 0 }}>
+                            <span style={{ padding: '2px 8px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, textTransform: 'uppercase', background: SEVERITY_BG[bug.severity] || 'var(--surface-container-high)', color: SEVERITY_COLOR[bug.severity] || 'var(--on-surface-variant)' }}>{bug.severity || 'unknown'}</span>
+                            <span style={{ padding: '2px 8px', borderRadius: '999px', fontSize: '10px', fontWeight: 600, background: 'var(--surface-container-high)', color: 'var(--on-surface-variant)' }}>×{bug.occurrence_count || 1}</span>
+                          </div>
+                        </div>
+                        {bug.page_url && <div style={{ fontFamily: 'monospace', fontSize: '0.72rem', color: 'var(--outline)', marginBottom: '4px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{bug.page_url}</div>}
+                        <div style={{ fontSize: '0.72rem', color: 'var(--on-surface-variant)', display: 'flex', gap: '12px' }}>
+                          {bug.first_seen_run_id && <span>First seen: <code style={{ fontFamily: 'monospace' }}>{bug.first_seen_run_id.slice(0, 8)}…</code></span>}
+                          {bug.last_seen_run_id && <span>Last seen: <code style={{ fontFamily: 'monospace' }}>{bug.last_seen_run_id.slice(0, 8)}…</code></span>}
+                        </div>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -180,6 +426,8 @@ export default function AppList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [modal, setModal] = useState(null);
+  const [memoryApp, setMemoryApp] = useState(null);
+  const [runApp, setRunApp] = useState(null);
 
   const fetchApps = React.useCallback(() => {
     api.get('/apps')
@@ -199,15 +447,15 @@ export default function AppList() {
   return (
     <div>
       {/* Page header */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '2.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
-          <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-tertiary-container)', textTransform: 'uppercase', letterSpacing: '0.2em', marginBottom: '6px' }}>Asset Management</span>
-          <h2 style={{ fontSize: '2.25rem', fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--primary)' }}>Application Inventory</h2>
+          <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.14em', marginBottom: '6px' }}>Asset management</span>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--primary)' }}>Applications</h1>
           <p style={{ color: 'var(--on-surface-variant)', marginTop: '6px', fontSize: '0.875rem', maxWidth: '480px' }}>Manage and monitor the security posture of your registered enterprise assets.</p>
         </div>
-        <button onClick={() => setModal('new')} style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '12px 20px', background: 'linear-gradient(135deg, var(--primary), var(--primary-container))', color: '#fff', border: 'none', borderRadius: '8px', fontWeight: 500, fontSize: '0.875rem' }}>
-          <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>add_circle</span>
-          Add Application
+        <button type="button" onClick={() => setModal('new')} className="btn-primary">
+          <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>add</span>
+          Add application
         </button>
       </div>
 
@@ -229,9 +477,9 @@ export default function AppList() {
           <p style={{ fontSize: '0.875rem' }}>Add your first app to start security testing.</p>
         </div>
       ) : (
-        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '12px', overflow: 'hidden', border: '1px solid rgba(197,198,207,0.15)' }}>
+        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', overflow: 'hidden', border: '1px solid var(--border-subtle)' }}>
           {/* Table header */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 120px 160px 100px', padding: '14px 24px', background: 'var(--surface-container-low)', fontSize: '10px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.12em' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 120px 160px 140px', padding: '14px 24px', background: 'var(--table-header-bg)', fontSize: '10px', fontWeight: 700, color: 'var(--on-surface)', textTransform: 'uppercase', letterSpacing: '0.12em', borderBottom: '1px solid var(--border-subtle)' }}>
             <span>Application Name & URL</span>
             <span style={{ textAlign: 'center' }}>Auth</span>
             <span>Added</span>
@@ -241,13 +489,13 @@ export default function AppList() {
           {/* Rows */}
           <div>
             {apps.map((app, idx) => (
-              <div key={app.id} className="hoverable-row" style={{ display: 'grid', gridTemplateColumns: '1fr 120px 160px 100px', alignItems: 'center', padding: '16px 24px', borderLeft: '3px solid var(--secondary)', borderBottom: idx < apps.length - 1 ? '1px solid var(--surface-container-low)' : 'none' }}>
+              <div key={app.id} className="hoverable-row" style={{ display: 'grid', gridTemplateColumns: '1fr 120px 160px 140px', alignItems: 'center', padding: '16px 24px', borderLeft: '3px solid var(--secondary)', borderBottom: idx < apps.length - 1 ? '1px solid var(--border-subtle)' : 'none' }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                  <div style={{ width: '36px', height: '36px', borderRadius: '6px', background: 'rgba(0,88,190,0.06)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                  <div style={{ width: '36px', height: '36px', borderRadius: '6px', background: 'var(--secondary-soft)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                     <span className="material-symbols-outlined" style={{ color: 'var(--secondary)', fontSize: '18px' }}>cloud_done</span>
                   </div>
                   <div>
-                    <div style={{ fontWeight: 600, fontSize: '0.875rem', color: 'var(--primary)', marginBottom: '2px' }}>{app.name}</div>
+                    <div style={{ fontWeight: 600, fontSize: '0.875rem', color: 'var(--link)', marginBottom: '2px' }}>{app.name}</div>
                     <a href={app.url} target="_blank" rel="noopener noreferrer" style={{ fontSize: '0.75rem', color: 'var(--outline)', fontFamily: 'monospace' }}>{app.url}</a>
                   </div>
                 </div>
@@ -255,7 +503,7 @@ export default function AppList() {
                   {app.credentials?.login_flow ? (
                     <span style={{ padding: '3px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: 'rgba(176,141,91,0.1)', color: 'var(--on-tertiary-container)', textTransform: 'uppercase' }}>SSO</span>
                   ) : app.credentials?.username ? (
-                    <span style={{ padding: '3px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: 'rgba(0,88,190,0.08)', color: 'var(--secondary)', textTransform: 'uppercase' }}>Login</span>
+                    <span style={{ padding: '3px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: 'var(--secondary-soft)', color: 'var(--secondary)', textTransform: 'uppercase' }}>Login</span>
                   ) : (
                     <span style={{ padding: '3px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: 'var(--surface-container-high)', color: 'var(--on-surface-variant)', textTransform: 'uppercase' }}>None</span>
                   )}
@@ -263,7 +511,16 @@ export default function AppList() {
                 <span style={{ fontSize: '0.8rem', color: 'var(--on-surface-variant)' }}>
                   {app.created_at ? new Date(app.created_at).toLocaleDateString() : '—'}
                 </span>
-                <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                <div style={{ display: 'flex', gap: '6px', justifyContent: 'flex-end', alignItems: 'center' }}>
+                  <button onClick={() => setRunApp(app)}
+                    style={{ padding: '5px 10px', borderRadius: '6px', fontSize: '11px', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '3px', background: 'var(--primary-button)', color: '#fff', border: 'none', cursor: 'pointer' }}
+                    title="Start test run">
+                    <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>play_arrow</span>
+                    Run
+                  </button>
+                  <button onClick={() => setMemoryApp(app)} style={{ padding: '6px', background: 'none', border: 'none', color: 'var(--secondary)' }} title="View agent memory">
+                    <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>psychology</span>
+                  </button>
                   <button onClick={() => setModal(app)} style={{ padding: '6px', background: 'none', border: 'none', color: 'var(--on-surface-variant)' }} title="Edit">
                     <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>edit</span>
                   </button>
@@ -276,7 +533,7 @@ export default function AppList() {
           </div>
 
           {/* Footer */}
-          <div style={{ padding: '12px 24px', background: 'var(--surface-container-low)', fontSize: '0.75rem', color: 'var(--on-surface-variant)' }}>
+          <div style={{ padding: '12px 24px', background: 'var(--surface-container-low)', fontSize: '0.75rem', color: 'var(--on-surface-variant)', borderTop: '1px solid var(--border-subtle)' }}>
             Showing {apps.length} application{apps.length !== 1 ? 's' : ''}
           </div>
         </div>
@@ -287,6 +544,14 @@ export default function AppList() {
           app={modal === 'new' ? null : modal}
           onClose={() => setModal(null)}
           onSave={() => { setModal(null); fetchApps(); }}
+        />
+      )}
+      {memoryApp && <MemoryModal app={memoryApp} onClose={() => setMemoryApp(null)} />}
+      {runApp && (
+        <NewRunModal
+          defaultAppId={runApp.id}
+          onClose={() => setRunApp(null)}
+          onCreated={() => setRunApp(null)}
         />
       )}
     </div>

--- a/frontend/src/components/AppList.jsx
+++ b/frontend/src/components/AppList.jsx
@@ -126,7 +126,7 @@ function AppModal({ app, onClose, onSave }) {
           <div>
             <label style={labelStyle}>Authentication</label>
             <div style={{ display: 'flex', gap: '8px' }}>
-              {[{ value: 'none', label: 'None' }, { value: 'simple', label: 'Simple Login' }, { value: 'sso', label: 'SSO / Multi-Step' }].map(opt => (
+              {[{ value: 'none', label: 'None' }, { value: 'simple', label: 'Smart Login (Auto)' }, { value: 'sso', label: 'SSO / Multi-Step' }].map(opt => (
                 <button key={opt.value} type="button" onClick={() => setAuthMode(opt.value)} style={{
                   flex: 1, padding: '9px 6px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 500,
                   border: authMode === opt.value ? '2px solid var(--secondary)' : '1px solid var(--outline-variant)',
@@ -140,7 +140,7 @@ function AppModal({ app, onClose, onSave }) {
           {authMode === 'simple' && (
             <div style={{ background: 'var(--surface-container-low)', borderRadius: '10px', padding: '1rem', display: 'flex', flexDirection: 'column', gap: '10px' }}>
               <div>
-                <label style={labelStyle}>Username / Email</label>
+                <label style={labelStyle}>Email</label>
                 <input type="text" value={form.username} onChange={e => setForm({ ...form, username: e.target.value })} placeholder="user@example.com" className="ent-input" style={inputStyle} />
               </div>
               <div>

--- a/frontend/src/components/BugList.jsx
+++ b/frontend/src/components/BugList.jsx
@@ -1,0 +1,211 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { formatDistanceToNow } from 'date-fns';
+import api from '../services/api.js';
+
+const SEVERITY_STYLE = {
+  critical: { bg: 'var(--error-container)', color: 'var(--error)' },
+  high:     { bg: '#fef3c7', color: '#92400e' },
+  medium:   { bg: 'var(--secondary-soft)', color: 'var(--secondary)' },
+  low:      { bg: 'var(--surface-container-high)', color: 'var(--on-surface-variant)' },
+};
+
+export default function BugList() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const appId = searchParams.get('app_id') || '';
+  const severityFilter = searchParams.get('severity') || '';
+
+  const [bugs, setBugs] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [apps, setApps] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const queryString = useMemo(() => {
+    const p = new URLSearchParams();
+    if (appId) p.set('app_id', appId);
+    if (severityFilter) p.set('severity', severityFilter);
+    p.set('limit', '100');
+    return p.toString();
+  }, [appId, severityFilter]);
+
+  const fetchBugs = useCallback(() => {
+    setLoading(true);
+    api
+      .get(`/bugs?${queryString}`)
+      .then((res) => {
+        setBugs(res.data.bugs || []);
+        setTotal(res.data.total ?? res.data.bugs?.length ?? 0);
+        setError(null);
+      })
+      .catch((err) => setError(err.response?.data?.error || err.message || 'Failed to load bugs'))
+      .finally(() => setLoading(false));
+  }, [queryString]);
+
+  useEffect(() => {
+    api.get('/apps').then((res) => setApps(res.data.apps || [])).catch(() => setApps([]));
+  }, []);
+
+  useEffect(() => {
+    fetchBugs();
+  }, [fetchBugs]);
+
+  const handleAppChange = (e) => {
+    const v = e.target.value;
+    const next = new URLSearchParams(searchParams);
+    if (v) next.set('app_id', v);
+    else next.delete('app_id');
+    setSearchParams(next);
+  };
+
+  const handleSeverityChange = (e) => {
+    const v = e.target.value;
+    const next = new URLSearchParams(searchParams);
+    if (v) next.set('severity', v);
+    else next.delete('severity');
+    setSearchParams(next);
+  };
+
+  const titleSuffix =
+    severityFilter === 'critical'
+      ? ' — Critical'
+      : severityFilter
+        ? ` — ${severityFilter.charAt(0).toUpperCase()}${severityFilter.slice(1)}`
+        : '';
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
+        <div>
+          <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.14em', marginBottom: '6px' }}>Findings</span>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--primary)' }}>
+            Bug reports{titleSuffix}
+          </h1>
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', alignItems: 'center' }}>
+          <label style={{ fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--on-surface-variant)', display: 'flex', alignItems: 'center', gap: '8px' }}>
+            App
+            <select
+              value={appId}
+              onChange={handleAppChange}
+              className="ent-input"
+              style={{ minWidth: '180px', padding: '8px 12px', borderRadius: '8px', fontSize: '0.875rem', border: '1px solid var(--border-subtle)', background: 'var(--surface-container-lowest)', color: 'var(--on-surface)' }}
+            >
+              <option value="">All apps</option>
+              {apps.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name || a.url || a.id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={{ fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--on-surface-variant)', display: 'flex', alignItems: 'center', gap: '8px' }}>
+            Severity
+            <select
+              value={severityFilter}
+              onChange={handleSeverityChange}
+              className="ent-input"
+              style={{ minWidth: '140px', padding: '8px 12px', borderRadius: '8px', fontSize: '0.875rem', border: '1px solid var(--border-subtle)', background: 'var(--surface-container-lowest)', color: 'var(--on-surface)' }}
+            >
+              <option value="">All severities</option>
+              <option value="critical">Critical</option>
+              <option value="high">High</option>
+              <option value="medium">Medium</option>
+              <option value="low">Low</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ background: 'var(--error-container)', color: 'var(--error)', padding: '12px 16px', borderRadius: '8px', marginBottom: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.875rem' }}>
+          <span>{error}</span>
+          <button type="button" onClick={() => { setError(null); fetchBugs(); }} style={{ background: 'none', border: 'none', color: 'var(--error)', fontWeight: 600 }}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--on-surface-variant)', padding: '2rem 0' }}>
+          <span className="material-symbols-outlined pulse" style={{ color: 'var(--link)' }}>
+            autorenew
+          </span>
+          Loading bugs...
+        </div>
+      ) : (
+        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', border: '1px solid var(--border-subtle)', overflow: 'hidden' }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 1.5fr) 120px 140px 100px',
+              padding: '12px 20px',
+              fontSize: '10px',
+              fontWeight: 700,
+              color: 'var(--on-surface)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.12em',
+              background: 'var(--table-header-bg)',
+              borderBottom: '1px solid var(--border-subtle)',
+            }}
+          >
+            <span>Title</span>
+            <span>Severity</span>
+            <span>Application</span>
+            <span style={{ textAlign: 'right' }}>Reported</span>
+          </div>
+          {bugs.length === 0 ? (
+            <div style={{ padding: '3rem', textAlign: 'center', color: 'var(--on-surface-variant)' }}>
+              <span className="material-symbols-outlined" style={{ fontSize: '40px', color: 'var(--outline-variant)', display: 'block', marginBottom: '12px' }}>
+                pest_control
+              </span>
+              No bugs match the current filters.
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              {bugs.map((bug, idx) => {
+                const sev = bug.severity || 'medium';
+                const badge = SEVERITY_STYLE[sev] || SEVERITY_STYLE.medium;
+                return (
+                  <div
+                    key={bug.id}
+                    className="hoverable-card"
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'minmax(0, 1.5fr) 120px 140px 100px',
+                      alignItems: 'center',
+                      padding: '14px 20px',
+                      borderBottom: idx < bugs.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+                      gap: '8px',
+                    }}
+                  >
+                    <div style={{ minWidth: 0 }}>
+                      <Link to={`/runs/${bug.run_id}`} style={{ fontWeight: 600, fontSize: '0.875rem', color: 'var(--link)', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={bug.title}>
+                        {bug.title || 'Untitled'}
+                      </Link>
+                      <span style={{ fontSize: '0.7rem', color: 'var(--outline)' }}>Run #{bug.run_id?.toString?.().slice(-6) || '—'}</span>
+                    </div>
+                    <span style={{ padding: '3px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: badge.bg, color: badge.color, justifySelf: 'start' }}>
+                      {sev}
+                    </span>
+                    <span style={{ fontSize: '0.8rem', color: 'var(--on-surface-variant)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={bug.app_name}>
+                      {bug.app_name || '—'}
+                    </span>
+                    <span style={{ fontSize: '0.8rem', color: 'var(--on-surface-variant)', textAlign: 'right' }}>
+                      {bug.created_at ? formatDistanceToNow(new Date(bug.created_at), { addSuffix: true }) : '—'}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {bugs.length > 0 && (
+            <div style={{ padding: '12px 20px', fontSize: '0.75rem', color: 'var(--on-surface-variant)' }}>
+              Showing {bugs.length} of {total} bug{total !== 1 ? 's' : ''}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/BugReports.jsx
+++ b/frontend/src/components/BugReports.jsx
@@ -1,93 +1,330 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { formatDistanceToNow } from 'date-fns';
+import { formatDistanceToNow, format } from 'date-fns';
 import api from '../services/api.js';
 
 const ACTIVE_STATUSES = new Set(['pending', 'running']);
 
 const SEVERITY_CONFIG = {
-  critical: { bg: 'var(--error-container)', color: 'var(--error)',           rail: 'var(--error)',           icon: 'crisis_alert' },
-  high:     { bg: '#ffedd5', color: '#9a3412',                               rail: '#ea580c',                icon: 'warning' },
-  medium:   { bg: '#fef3c7', color: '#92400e',                               rail: 'var(--on-tertiary-container)', icon: 'info' },
-  low:      { bg: '#f0fdf4', color: '#16a34a',                               rail: '#22c55e',                icon: 'check_circle' },
+  critical: { bg: 'var(--error-container)', color: 'var(--error)',                rail: 'var(--error)',                icon: 'crisis_alert' },
+  high:     { bg: '#ffedd5',               color: '#9a3412',                      rail: '#ea580c',                     icon: 'warning' },
+  medium:   { bg: '#fef3c7',               color: '#92400e',                      rail: 'var(--on-tertiary-container)', icon: 'info' },
+  low:      { bg: '#f0fdf4',               color: '#16a34a',                      rail: '#22c55e',                     icon: 'check_circle' },
 };
 
 const STATUS_CONFIG = {
   open:      { bg: 'rgba(0,88,190,0.08)', color: 'var(--secondary)' },
-  confirmed: { bg: '#ede9fe', color: '#5b21b6' },
-  fixed:     { bg: '#f0fdf4', color: '#16a34a' },
+  confirmed: { bg: '#ede9fe',             color: '#5b21b6' },
+  fixed:     { bg: '#f0fdf4',             color: '#16a34a' },
   wontfix:   { bg: 'var(--surface-container-high)', color: 'var(--on-surface-variant)' },
 };
 
-// Event type → display config for the live activity panel
 const EVENT_CONFIG = {
-  agent_start:  { color: 'var(--secondary)',  icon: 'play_circle' },
-  agent_done:   { color: '#16a34a',           icon: 'check_circle' },
-  page_visited: { color: 'var(--outline)',    icon: 'travel_explore' },
-  bug_found:    { color: 'var(--error)',      icon: 'bug_report' },
-  run_complete: { color: '#16a34a',           icon: 'verified' },
-  run_failed:   { color: 'var(--error)',      icon: 'error' },
+  agent_start:  { color: 'var(--secondary)', icon: 'play_circle' },
+  agent_done:   { color: '#16a34a',          icon: 'check_circle' },
+  page_visited: { color: 'var(--outline)',   icon: 'travel_explore' },
+  bug_found:    { color: 'var(--error)',     icon: 'bug_report' },
+  run_complete: { color: '#16a34a',          icon: 'verified' },
+  run_failed:   { color: 'var(--error)',     icon: 'error' },
 };
 
-function BugCard({ bug, onStatusChange }) {
-  const [expanded, setExpanded] = useState(false);
-  const sev = SEVERITY_CONFIG[bug.severity] || SEVERITY_CONFIG.medium;
-  const sta = STATUS_CONFIG[bug.status] || STATUS_CONFIG.open;
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function duration(start, end) {
+  if (!start || !end) return null;
+  const s = Math.round((new Date(end) - new Date(start)) / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+}
+
+function SevBadge({ severity, count }) {
+  const cfg = SEVERITY_CONFIG[severity];
+  if (!cfg || count === 0) return null;
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '4px', padding: '3px 10px', borderRadius: '999px', fontSize: '11px', fontWeight: 700, background: cfg.bg, color: cfg.color }}>
+      <span className="material-symbols-outlined" style={{ fontSize: '12px', fontVariationSettings: "'FILL' 1" }}>{cfg.icon}</span>
+      {count} {severity}
+    </span>
+  );
+}
+
+// ─── Lightbox ────────────────────────────────────────────────────────────────
+
+function Lightbox({ src, label, onClose }) {
+  useEffect(() => {
+    const handler = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
 
   return (
-    <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '10px', marginBottom: '8px', overflow: 'hidden', borderLeft: `3px solid ${sev.rail}` }}>
-      {/* Header row */}
-      <div onClick={() => setExpanded(!expanded)} style={{ padding: '1rem 1.25rem', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '12px' }}>
-        <span className="material-symbols-outlined" style={{ color: sev.rail, fontSize: '20px', flexShrink: 0, fontVariationSettings: "'FILL' 1" }}>{sev.icon}</span>
-        <span style={{ padding: '2px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: sev.bg, color: sev.color, textTransform: 'uppercase', flexShrink: 0 }}>
-          {bug.severity}
-        </span>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--primary)', marginBottom: '2px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{bug.title}</div>
-          <div style={{ fontSize: '0.75rem', color: 'var(--outline)', fontFamily: 'monospace' }}>{bug.page_url}</div>
+    <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.85)', zIndex: 200, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '2rem' }}>
+      <div onClick={e => e.stopPropagation()} style={{ maxWidth: '90vw', maxHeight: '85vh', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ color: '#fff', fontSize: '0.875rem', fontWeight: 500 }}>{label}</span>
+          <button onClick={onClose} style={{ background: 'rgba(255,255,255,0.1)', border: 'none', color: '#fff', borderRadius: '6px', padding: '4px 10px', cursor: 'pointer', fontSize: '0.8rem' }}>
+            Close (Esc)
+          </button>
         </div>
-        <span style={{ padding: '2px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 600, background: sta.bg, color: sta.color, textTransform: 'uppercase', flexShrink: 0 }}>
-          {bug.status}
-        </span>
-        <span className="material-symbols-outlined" style={{ color: 'var(--outline)', fontSize: '18px', flexShrink: 0 }}>
-          {expanded ? 'expand_less' : 'expand_more'}
-        </span>
+        <img src={src} alt={label} style={{ maxWidth: '100%', maxHeight: 'calc(85vh - 60px)', borderRadius: '8px', objectFit: 'contain' }} />
       </div>
+    </div>
+  );
+}
 
-      {/* Expanded detail */}
-      {expanded && (
-        <div style={{ padding: '0 1.25rem 1.25rem', borderTop: '1px solid var(--surface-container-low)' }}>
-          {[
-            { label: 'Description', value: bug.description },
-            { label: 'Steps to Reproduce', value: bug.steps_to_reproduce },
-            { label: 'Expected Behavior', value: bug.expected_behavior },
-            { label: 'Actual Behavior', value: bug.actual_behavior },
-          ].map(({ label, value }) => value ? (
-            <div key={label} style={{ marginTop: '1rem' }}>
-              <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '6px' }}>{label}</div>
-              <div style={{ fontSize: '0.875rem', color: 'var(--on-surface)', whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{value}</div>
+// ─── Screenshots Gallery ─────────────────────────────────────────────────────
+
+function ScreenshotsGallery({ bugs }) {
+  const [lightbox, setLightbox] = useState(null);
+  const withScreenshots = bugs.filter(b => b.screenshot_url);
+  if (withScreenshots.length === 0) return null;
+
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '10px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>photo_library</span>
+        Screenshots ({withScreenshots.length})
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '10px' }}>
+        {withScreenshots.map(bug => {
+          const sev = SEVERITY_CONFIG[bug.severity] || SEVERITY_CONFIG.medium;
+          return (
+            <div key={bug.id} onClick={() => setLightbox({ src: bug.screenshot_url, label: bug.title })}
+              style={{ cursor: 'pointer', borderRadius: '8px', overflow: 'hidden', border: `2px solid ${sev.rail}`, background: 'var(--surface-container-lowest)', transition: 'transform 0.15s', position: 'relative' }}
+              onMouseEnter={e => e.currentTarget.style.transform = 'scale(1.02)'}
+              onMouseLeave={e => e.currentTarget.style.transform = 'scale(1)'}>
+              <img src={bug.screenshot_url} alt={bug.title} style={{ width: '100%', height: '110px', objectFit: 'cover', display: 'block' }} />
+              <div style={{ padding: '6px 8px', borderTop: `1px solid ${sev.rail}22` }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '2px' }}>
+                  <span style={{ padding: '1px 6px', borderRadius: '999px', fontSize: '9px', fontWeight: 700, background: sev.bg, color: sev.color, textTransform: 'uppercase' }}>{bug.severity}</span>
+                </div>
+                <div style={{ fontSize: '0.7rem', color: 'var(--on-surface)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 500 }}>{bug.title}</div>
+              </div>
+              <div style={{ position: 'absolute', top: '6px', right: '6px', background: 'rgba(0,0,0,0.5)', borderRadius: '4px', padding: '2px 4px' }}>
+                <span className="material-symbols-outlined" style={{ fontSize: '14px', color: '#fff' }}>zoom_in</span>
+              </div>
             </div>
-          ) : null)}
+          );
+        })}
+      </div>
+      {lightbox && <Lightbox src={lightbox.src} label={lightbox.label} onClose={() => setLightbox(null)} />}
+    </div>
+  );
+}
 
-          {bug.screenshot_url && (
-            <div style={{ marginTop: '1rem' }}>
-              <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px' }}>Screenshot</div>
-              <img src={bug.screenshot_url} alt="Bug screenshot" style={{ maxWidth: '100%', borderRadius: '8px', border: '1px solid var(--outline-variant)' }} />
+// ─── Run Overview Card ────────────────────────────────────────────────────────
+
+function RunOverviewCard({ run, bugs }) {
+  const sevCounts = { critical: 0, high: 0, medium: 0, low: 0 };
+  bugs.forEach(b => { if (sevCounts[b.severity] !== undefined) sevCounts[b.severity]++; });
+  const dur = duration(run.started_at, run.completed_at);
+  const isCompleted = run.status === 'completed';
+  const isFailed    = run.status === 'failed';
+  const isActive    = ACTIVE_STATUSES.has(run.status);
+
+  const statusStyle = isCompleted
+    ? { bg: '#f0fdf4', color: '#16a34a', icon: 'verified', label: 'Completed' }
+    : isFailed
+    ? { bg: 'var(--error-container)', color: 'var(--error)', icon: 'error', label: 'Failed' }
+    : { bg: 'rgba(0,88,190,0.08)', color: 'var(--secondary)', icon: 'autorenew', label: run.status.toUpperCase() };
+
+  return (
+    <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '12px', marginBottom: '1.5rem', overflow: 'hidden', border: '1px solid rgba(197,198,207,0.15)' }}>
+      {/* Status bar */}
+      <div style={{ height: '4px', background: isCompleted ? '#22c55e' : isFailed ? 'var(--error)' : 'var(--secondary)' }} />
+
+      <div style={{ padding: '1.25rem 1.5rem' }}>
+        {/* Top row */}
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap', marginBottom: '1rem' }}>
+          <div>
+            <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: '4px' }}>Target Application</div>
+            <div style={{ fontSize: '1rem', fontWeight: 600, color: 'var(--primary)', marginBottom: '2px' }}>{run.app_name}</div>
+            <a href={run.app_url} target="_blank" rel="noopener noreferrer" style={{ fontSize: '0.8rem', color: 'var(--outline)', fontFamily: 'monospace' }}>{run.app_url}</a>
+          </div>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', padding: '6px 14px', borderRadius: '999px', fontSize: '0.75rem', fontWeight: 700, background: statusStyle.bg, color: statusStyle.color }}>
+            <span className={`material-symbols-outlined${isActive ? ' pulse' : ''}`} style={{ fontSize: '14px', fontVariationSettings: "'FILL' 1" }}>{statusStyle.icon}</span>
+            {statusStyle.label}
+          </span>
+        </div>
+
+        {/* Metrics row */}
+        <div style={{ display: 'flex', gap: '1.5rem', flexWrap: 'wrap', fontSize: '0.8rem', marginBottom: '1rem', color: 'var(--on-surface-variant)' }}>
+          {run.started_at && (
+            <div>
+              <span style={{ fontWeight: 600, color: 'var(--on-surface)' }}>Started </span>
+              {format(new Date(run.started_at), 'MMM d, yyyy HH:mm')}
             </div>
           )}
+          {run.completed_at && (
+            <div>
+              <span style={{ fontWeight: 600, color: 'var(--on-surface)' }}>Finished </span>
+              {format(new Date(run.completed_at), 'HH:mm:ss')}
+            </div>
+          )}
+          {dur && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>timer</span>
+              <span style={{ fontWeight: 600, color: 'var(--on-surface)' }}>Duration </span>{dur}
+            </div>
+          )}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <span className="material-symbols-outlined" style={{ fontSize: '14px', color: bugs.length > 0 ? 'var(--error)' : '#16a34a' }}>bug_report</span>
+            <span style={{ fontWeight: 600, color: 'var(--on-surface)' }}>{bugs.length} bug{bugs.length !== 1 ? 's' : ''} found</span>
+          </div>
+        </div>
 
-          {/* Status update */}
-          <div style={{ marginTop: '1.25rem', display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
-            <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Update Status:</span>
-            {['open', 'confirmed', 'fixed', 'wontfix'].map(s => (
-              <button key={s} onClick={() => onStatusChange(bug.id, s)} disabled={bug.status === s} style={{
-                padding: '5px 12px', borderRadius: '6px', fontSize: '0.75rem', fontWeight: 500,
-                border: bug.status === s ? 'none' : '1px solid var(--outline-variant)',
-                background: bug.status === s ? 'var(--primary)' : 'transparent',
-                color: bug.status === s ? '#fff' : 'var(--on-surface-variant)',
-                cursor: bug.status === s ? 'default' : 'pointer',
-              }}>{s}</button>
+        {/* Severity breakdown */}
+        {bugs.length > 0 && (
+          <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+            {['critical', 'high', 'medium', 'low'].map(s => (
+              <SevBadge key={s} severity={s} count={sevCounts[s]} />
             ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Pages Explored ───────────────────────────────────────────────────────────
+
+function PagesExplored({ summary, accentColor = '#16a34a' }) {
+  const [lightbox, setLightbox] = useState(null);
+  const [expandedPage, setExpandedPage] = useState(null);
+
+  const pages = summary?.pages_visited || [];
+  if (pages.length === 0) return null;
+
+  const ACTION_LABELS = {
+    observe:                'Analysed page for test opportunities',
+    login_attempt:          'Attempted login',
+    login_flow_completed:   'Login flow completed',
+    login_flow_failed:      'Login flow failed',
+    errors_detected:        'Console / network errors detected',
+    error:                  'Error encountered',
+  };
+
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '10px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>travel_explore</span>
+        Pages Explored ({pages.length})
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        {pages.map((page, i) => {
+          const imgSrc = page.screenshot_file ? `/screenshots/${page.screenshot_file}` : null;
+          const isExpanded = expandedPage === i;
+
+          return (
+            <div key={i} style={{ background: 'var(--surface-container-lowest)', borderRadius: '10px', overflow: 'hidden', border: '1px solid rgba(197,198,207,0.15)', borderLeft: `3px solid ${accentColor}` }}>
+              {/* Row header */}
+              <div onClick={() => setExpandedPage(isExpanded ? null : i)}
+                style={{ display: 'flex', alignItems: 'center', gap: '12px', padding: '10px 14px', cursor: 'pointer' }}>
+                {/* Thumbnail */}
+                {imgSrc ? (
+                  <div onClick={e => { e.stopPropagation(); setLightbox({ src: imgSrc, label: page.url }); }}
+                    style={{ flexShrink: 0, width: '72px', height: '46px', borderRadius: '5px', overflow: 'hidden', border: '1px solid rgba(197,198,207,0.3)', cursor: 'zoom-in', position: 'relative' }}>
+                    <img src={imgSrc} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                    <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.12)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                      <span className="material-symbols-outlined" style={{ fontSize: '16px', color: '#fff' }}>zoom_in</span>
+                    </div>
+                  </div>
+                ) : (
+                  <div style={{ flexShrink: 0, width: '72px', height: '46px', borderRadius: '5px', background: 'var(--surface-container-low)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <span className="material-symbols-outlined" style={{ fontSize: '20px', color: 'var(--outline-variant)' }}>image_not_supported</span>
+                  </div>
+                )}
+
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px' }}>
+                    <span style={{ fontSize: '10px', fontWeight: 700, color: 'var(--on-surface-variant)', background: 'var(--surface-container-low)', padding: '1px 6px', borderRadius: '4px' }}>
+                      Page {i + 1}
+                    </span>
+                    {page.steps?.length > 0 && (
+                      <span style={{ fontSize: '10px', color: 'var(--outline)' }}>{page.steps.length} action{page.steps.length !== 1 ? 's' : ''}</span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: '0.78rem', color: 'var(--on-surface)', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <a href={page.url} target="_blank" rel="noopener noreferrer"
+                      onClick={e => e.stopPropagation()}
+                      style={{ color: accentColor, textDecoration: 'none' }}>{page.url}</a>
+                  </div>
+                </div>
+
+                <span className="material-symbols-outlined" style={{ color: 'var(--outline)', fontSize: '18px', flexShrink: 0 }}>
+                  {isExpanded ? 'expand_less' : 'expand_more'}
+                </span>
+              </div>
+
+              {/* Expanded: full screenshot + what was tested */}
+              {isExpanded && (
+                <div style={{ padding: '0 14px 14px', borderTop: '1px solid var(--surface-container-low)' }}>
+                  {imgSrc && (
+                    <div style={{ marginTop: '12px', cursor: 'zoom-in' }} onClick={() => setLightbox({ src: imgSrc, label: page.url })}>
+                      <img src={imgSrc} alt={page.url}
+                        style={{ width: '100%', maxHeight: '340px', objectFit: 'contain', borderRadius: '8px', border: '1px solid rgba(197,198,207,0.3)', display: 'block' }} />
+                      <div style={{ fontSize: '0.7rem', color: 'var(--outline)', marginTop: '4px', textAlign: 'center' }}>Click to open full size</div>
+                    </div>
+                  )}
+
+                  {page.steps?.length > 0 && (
+                    <div style={{ marginTop: '12px' }}>
+                      <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px' }}>
+                        What Was Tested
+                      </div>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                        {page.steps.map((step, si) => (
+                          <div key={si} style={{ display: 'flex', gap: '8px', fontSize: '0.8rem', alignItems: 'flex-start' }}>
+                            <span className="material-symbols-outlined" style={{ fontSize: '14px', color: step.action === 'error' || step.action === 'login_flow_failed' ? 'var(--error)' : accentColor, flexShrink: 0, marginTop: '1px' }}>
+                              {step.action === 'observe' ? 'search' : step.action.includes('login') ? 'key' : step.action === 'errors_detected' ? 'warning' : 'info'}
+                            </span>
+                            <div>
+                              <span style={{ fontWeight: 500, color: 'var(--on-surface)' }}>{ACTION_LABELS[step.action] || step.action}</span>
+                              {step.detail && typeof step.detail === 'string' && step.detail.length < 200 && (
+                                <div style={{ color: 'var(--on-surface-variant)', marginTop: '2px', whiteSpace: 'pre-wrap' }}>{step.detail}</div>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {lightbox && <Lightbox src={lightbox.src} label={lightbox.label} onClose={() => setLightbox(null)} />}
+    </div>
+  );
+}
+
+// ─── Success Summary Panel ────────────────────────────────────────────────────
+
+function SuccessPanel({ run, bugs }) {
+  const summary = run.summary || {};
+
+  return (
+    <div style={{ background: '#f0fdf4', border: '1px solid #bbf7d0', borderRadius: '12px', marginBottom: '1.5rem', overflow: 'hidden' }}>
+      <div style={{ padding: '0.875rem 1.25rem', display: 'flex', alignItems: 'center', gap: '8px', borderBottom: '1px solid #bbf7d0' }}>
+        <span className="material-symbols-outlined" style={{ fontSize: '18px', color: '#16a34a', fontVariationSettings: "'FILL' 1" }}>task_alt</span>
+        <span style={{ fontWeight: 600, fontSize: '0.875rem', color: '#15803d' }}>Scan Completed Successfully</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: '12px', fontSize: '0.8rem', color: '#166534' }}>
+          {summary.pages_explored > 0 && <span><strong>{summary.pages_explored}</strong> pages</span>}
+          {summary.screenshots_taken > 0 && <span><strong>{summary.screenshots_taken}</strong> screenshots</span>}
+          <span><strong>{bugs.length}</strong> bug{bugs.length !== 1 ? 's' : ''}</span>
+        </div>
+      </div>
+
+      {bugs.length === 0 && (
+        <div style={{ padding: '1rem 1.25rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '10px 14px', background: '#dcfce7', borderRadius: '8px' }}>
+            <span className="material-symbols-outlined" style={{ fontSize: '20px', color: '#16a34a', fontVariationSettings: "'FILL' 1" }}>shield</span>
+            <span style={{ fontSize: '0.875rem', color: '#15803d', fontWeight: 500 }}>No bugs found — the application passed all checks.</span>
           </div>
         </div>
       )}
@@ -95,12 +332,137 @@ function BugCard({ bug, onStatusChange }) {
   );
 }
 
+// ─── Failure Panel ────────────────────────────────────────────────────────────
+
+function FailurePanel({ run }) {
+  return (
+    <div style={{ background: 'var(--error-container)', border: '1px solid rgba(186,26,26,0.3)', borderRadius: '12px', marginBottom: '1.5rem', overflow: 'hidden' }}>
+      <div style={{ padding: '0.875rem 1.25rem', display: 'flex', alignItems: 'center', gap: '8px', borderBottom: '1px solid rgba(186,26,26,0.2)' }}>
+        <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--error)', fontVariationSettings: "'FILL' 1" }}>error</span>
+        <span style={{ fontWeight: 600, fontSize: '0.875rem', color: 'var(--error)' }}>Scan Failed</span>
+      </div>
+
+      <div style={{ padding: '1rem 1.25rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        {run.error && (
+          <div>
+            <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--error)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '6px' }}>Error Details</div>
+            <pre style={{ margin: 0, fontSize: '0.8rem', color: 'var(--error)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', background: 'rgba(186,26,26,0.08)', padding: '10px 14px', borderRadius: '8px', fontFamily: 'monospace', lineHeight: 1.5 }}>
+              {run.error}
+            </pre>
+          </div>
+        )}
+        <div style={{ fontSize: '0.8rem', color: 'var(--on-surface-variant)', display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>info</span>
+          Check <code style={{ background: 'rgba(0,0,0,0.06)', padding: '1px 5px', borderRadius: '4px' }}>logs/agent.log</code> for the full error trace.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Bug Card ─────────────────────────────────────────────────────────────────
+
+function BugCard({ bug, onStatusChange }) {
+  const [expanded, setExpanded] = useState(false);
+  const [lightbox, setLightbox] = useState(false);
+  const sev = SEVERITY_CONFIG[bug.severity] || SEVERITY_CONFIG.medium;
+  const sta = STATUS_CONFIG[bug.status] || STATUS_CONFIG.open;
+
+  const detailRows = [
+    { label: 'Description',         value: bug.description },
+    { label: 'Steps to Reproduce',  value: bug.steps_to_reproduce },
+    { label: 'Expected Behavior',   value: bug.expected_behavior },
+    { label: 'Actual Behavior',     value: bug.actual_behavior },
+  ].filter(r => r.value);
+
+  return (
+    <>
+      <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '10px', marginBottom: '8px', overflow: 'hidden', borderLeft: `3px solid ${sev.rail}` }}>
+        {/* Header row */}
+        <div onClick={() => setExpanded(!expanded)} style={{ padding: '1rem 1.25rem', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <span className="material-symbols-outlined" style={{ color: sev.rail, fontSize: '20px', flexShrink: 0, fontVariationSettings: "'FILL' 1" }}>{sev.icon}</span>
+          <span style={{ padding: '2px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: sev.bg, color: sev.color, textTransform: 'uppercase', flexShrink: 0 }}>
+            {bug.severity}
+          </span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--primary)', marginBottom: '2px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{bug.title}</div>
+            <div style={{ fontSize: '0.75rem', color: 'var(--outline)', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{bug.page_url}</div>
+          </div>
+          {/* Screenshot thumbnail in header */}
+          {bug.screenshot_url && (
+            <div onClick={e => { e.stopPropagation(); setLightbox(true); }}
+              style={{ flexShrink: 0, width: '56px', height: '36px', borderRadius: '4px', overflow: 'hidden', border: `1px solid ${sev.rail}44`, cursor: 'zoom-in', position: 'relative' }}>
+              <img src={bug.screenshot_url} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+              <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.15)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <span className="material-symbols-outlined" style={{ fontSize: '14px', color: '#fff' }}>zoom_in</span>
+              </div>
+            </div>
+          )}
+          <span style={{ padding: '2px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 600, background: sta.bg, color: sta.color, textTransform: 'uppercase', flexShrink: 0 }}>
+            {bug.status}
+          </span>
+          <span className="material-symbols-outlined" style={{ color: 'var(--outline)', fontSize: '18px', flexShrink: 0 }}>
+            {expanded ? 'expand_less' : 'expand_more'}
+          </span>
+        </div>
+
+        {/* Expanded detail */}
+        {expanded && (
+          <div style={{ padding: '0 1.25rem 1.25rem', borderTop: '1px solid var(--surface-container-low)' }}>
+            {/* Detail rows */}
+            {detailRows.map(({ label, value }) => (
+              <div key={label} style={{ marginTop: '1rem' }}>
+                <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '6px' }}>{label}</div>
+                <div style={{ fontSize: '0.875rem', color: 'var(--on-surface)', whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{value}</div>
+              </div>
+            ))}
+
+            {/* Full screenshot */}
+            {bug.screenshot_url && (
+              <div style={{ marginTop: '1rem' }}>
+                <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+                  <span className="material-symbols-outlined" style={{ fontSize: '13px' }}>screenshot</span>
+                  Screenshot
+                </div>
+                <div style={{ position: 'relative', display: 'inline-block', cursor: 'zoom-in' }} onClick={() => setLightbox(true)}>
+                  <img src={bug.screenshot_url} alt="Bug screenshot" style={{ maxWidth: '100%', maxHeight: '320px', objectFit: 'contain', borderRadius: '8px', border: `1px solid ${sev.rail}44`, display: 'block' }} />
+                  <div style={{ position: 'absolute', top: '8px', right: '8px', background: 'rgba(0,0,0,0.5)', borderRadius: '6px', padding: '4px 8px', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                    <span className="material-symbols-outlined" style={{ fontSize: '14px', color: '#fff' }}>zoom_in</span>
+                    <span style={{ fontSize: '0.7rem', color: '#fff' }}>Click to expand</span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Status update */}
+            <div style={{ marginTop: '1.25rem', display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
+              <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Update Status:</span>
+              {['open', 'confirmed', 'fixed', 'wontfix'].map(s => (
+                <button key={s} onClick={() => onStatusChange(bug.id, s)} disabled={bug.status === s} style={{
+                  padding: '5px 12px', borderRadius: '6px', fontSize: '0.75rem', fontWeight: 500,
+                  border: bug.status === s ? 'none' : '1px solid var(--outline-variant)',
+                  background: bug.status === s ? 'var(--primary)' : 'transparent',
+                  color: bug.status === s ? '#fff' : 'var(--on-surface-variant)',
+                  cursor: bug.status === s ? 'default' : 'pointer',
+                }}>{s}</button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {lightbox && bug.screenshot_url && (
+        <Lightbox src={bug.screenshot_url} label={bug.title} onClose={() => setLightbox(false)} />
+      )}
+    </>
+  );
+}
+
+// ─── Live Activity Panel ──────────────────────────────────────────────────────
+
 function LiveActivityPanel({ events }) {
   const bottomRef = useRef(null);
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [events]);
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [events]);
 
   return (
     <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '10px', padding: '1rem', maxHeight: '240px', overflowY: 'auto', fontFamily: 'monospace', fontSize: '0.78rem' }}>
@@ -124,19 +486,21 @@ function LiveActivityPanel({ events }) {
   );
 }
 
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
 export default function BugReports() {
   const { id } = useParams();
-  const [run, setRun] = useState(null);
-  const [bugs, setBugs] = useState([]);
-  const [filter, setFilter] = useState('all');
+  const [run, setRun]         = useState(null);
+  const [bugs, setBugs]       = useState([]);
+  const [filter, setFilter]   = useState('all');
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [liveEvents, setLiveEvents] = useState([]);
-  const [showLive, setShowLive] = useState(true);
-  const [generating, setGenerating] = useState(false);
-  const [featureContent, setFeatureContent] = useState(null);
+  const [error, setError]     = useState(null);
+  const [liveEvents, setLiveEvents]   = useState([]);
+  const [showLive, setShowLive]       = useState(true);
+  const [generating, setGenerating]   = useState(false);
+  const [featureContent, setFeatureContent]   = useState(null);
   const [featureFilename, setFeatureFilename] = useState('regression.feature');
-  const sseRef = useRef(null);
+  const sseRef  = useRef(null);
   const pollRef = useRef(null);
 
   const fetchData = useCallback(() => {
@@ -148,42 +512,31 @@ export default function BugReports() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  // SSE connection while run is active; polling fallback after SSE closes
+  // SSE while active; polling fallback
   useEffect(() => {
     const isActive = run && ACTIVE_STATUSES.has(run.status);
-
     if (isActive && !sseRef.current) {
       const token = localStorage.getItem('bughunter_token');
-      // EventSource doesn't support custom headers; pass token as query param
       const sse = new EventSource(`/api/runs/${id}/stream?token=${token}`);
       sseRef.current = sse;
-
       sse.onmessage = (e) => {
         try {
           const event = JSON.parse(e.data);
           setLiveEvents(prev => [...prev, event]);
-          // If the run is now done, refresh the data
           if (event.type === 'run_complete' || event.type === 'run_failed') {
             setTimeout(fetchData, 1000);
           }
-        } catch { /* ignore malformed events */ }
+        } catch { /* ignore */ }
       };
-
       sse.onerror = () => {
-        sse.close();
-        sseRef.current = null;
-        // Fall back to polling
-        if (!pollRef.current) {
-          pollRef.current = setInterval(fetchData, 5000);
-        }
+        sse.close(); sseRef.current = null;
+        if (!pollRef.current) pollRef.current = setInterval(fetchData, 5000);
       };
     }
-
     if (!isActive) {
       if (sseRef.current) { sseRef.current.close(); sseRef.current = null; }
       if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
     }
-
     return () => {
       if (sseRef.current) { sseRef.current.close(); sseRef.current = null; }
       if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
@@ -196,67 +549,53 @@ export default function BugReports() {
   };
 
   const handleGenerateTests = async () => {
-    setGenerating(true);
-    setFeatureContent(null);
+    setGenerating(true); setFeatureContent(null);
     try {
       const res = await api.post(`/runs/${id}/generate-tests`);
       setFeatureContent(res.data.feature_content);
       setFeatureFilename(res.data.filename || 'regression.feature');
     } catch (err) {
       setError(err.response?.data?.error || err.message || 'Failed to generate tests');
-    } finally {
-      setGenerating(false);
-    }
+    } finally { setGenerating(false); }
   };
 
   const handleDownload = () => {
     const blob = new Blob([featureContent], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const url  = URL.createObjectURL(blob);
+    const a    = document.createElement('a');
     a.href = url; a.download = featureFilename; a.click();
     URL.revokeObjectURL(url);
   };
 
-  const FILTERS = ['all', 'critical', 'high', 'medium', 'low'];
+  const FILTERS  = ['all', 'critical', 'high', 'medium', 'low'];
   const filtered = filter === 'all' ? bugs : bugs.filter(b => b.severity === filter);
   const countBySev = (s) => bugs.filter(b => b.severity === s).length;
   const isActive = run && ACTIVE_STATUSES.has(run.status);
 
   if (loading) return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--on-surface-variant)', padding: '2rem 0' }}>
-      <span className="material-symbols-outlined pulse" style={{ color: 'var(--secondary)' }}>autorenew</span> Loading...
+      <span className="material-symbols-outlined pulse" style={{ color: 'var(--secondary)' }}>autorenew</span> Loading…
     </div>
   );
 
   return (
     <div>
       {/* Page header */}
-      <div style={{ marginBottom: '1.5rem' }}>
-        <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-tertiary-container)', textTransform: 'uppercase', letterSpacing: '0.2em', marginBottom: '6px' }}>Vulnerability Report</span>
-        <h2 style={{ fontSize: '2.25rem', fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--primary)', marginBottom: '6px' }}>Bug Reports</h2>
-        {run && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
-            <span style={{ fontSize: '0.875rem', color: 'var(--on-surface-variant)' }}>
-              <strong style={{ color: 'var(--on-surface)' }}>{run.app_name}</strong>
-            </span>
-            <span style={{ width: '3px', height: '3px', borderRadius: '50%', background: 'var(--outline)' }} />
-            <span style={{ padding: '2px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: run.status === 'completed' ? '#f0fdf4' : run.status === 'failed' ? 'var(--error-container)' : 'rgba(0,88,190,0.08)', color: run.status === 'completed' ? '#16a34a' : run.status === 'failed' ? 'var(--error)' : 'var(--secondary)', textTransform: 'uppercase' }}>
-              {run.status}
-            </span>
-            <span style={{ fontSize: '0.875rem', color: 'var(--on-surface-variant)' }}>{bugs.length} bug{bugs.length !== 1 ? 's' : ''} found</span>
-            {/* Generate Tests button — only for completed runs with bugs */}
-            {run.status === 'completed' && bugs.length > 0 && (
-              <button onClick={handleGenerateTests} disabled={generating} style={{
-                marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '6px',
-                padding: '6px 14px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 600,
-                background: 'var(--primary)', color: '#fff', border: 'none', cursor: generating ? 'wait' : 'pointer',
-                opacity: generating ? 0.7 : 1,
-              }}>
-                <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>science</span>
-                {generating ? 'Generating…' : 'Generate Tests'}
-              </button>
-            )}
-          </div>
+      <div style={{ marginBottom: '1.5rem', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem' }}>
+        <div>
+          <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-tertiary-container)', textTransform: 'uppercase', letterSpacing: '0.2em', marginBottom: '6px' }}>Vulnerability Report</span>
+          <h2 style={{ fontSize: '2.25rem', fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--primary)', marginBottom: '4px' }}>Test Results</h2>
+        </div>
+        {run?.status === 'completed' && bugs.length > 0 && (
+          <button onClick={handleGenerateTests} disabled={generating} style={{
+            display: 'flex', alignItems: 'center', gap: '6px',
+            padding: '8px 16px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 600,
+            background: 'var(--primary)', color: '#fff', border: 'none', cursor: generating ? 'wait' : 'pointer',
+            opacity: generating ? 0.7 : 1,
+          }}>
+            <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>science</span>
+            {generating ? 'Generating…' : 'Generate Tests'}
+          </button>
         )}
       </div>
 
@@ -267,7 +606,10 @@ export default function BugReports() {
         </div>
       )}
 
-      {/* Live Activity Panel — shown while run is active */}
+      {/* Run overview */}
+      {run && <RunOverviewCard run={run} bugs={bugs} />}
+
+      {/* Live activity — while running */}
       {isActive && (
         <div style={{ marginBottom: '1.5rem', background: 'var(--surface-container-low)', borderRadius: '12px', overflow: 'hidden', border: '1px solid var(--outline-variant)' }}>
           <div onClick={() => setShowLive(!showLive)} style={{ padding: '10px 16px', display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
@@ -275,23 +617,30 @@ export default function BugReports() {
             <span style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--on-surface)', flex: 1 }}>Live Activity</span>
             <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--outline)' }}>{showLive ? 'expand_less' : 'expand_more'}</span>
           </div>
-          {showLive && (
-            <div style={{ padding: '0 12px 12px' }}>
-              <LiveActivityPanel events={liveEvents} />
-            </div>
-          )}
+          {showLive && <div style={{ padding: '0 12px 12px' }}><LiveActivityPanel events={liveEvents} /></div>}
         </div>
       )}
 
-      {/* Generated feature file output */}
+      {/* Success / Failure panels */}
+      {run?.status === 'completed' && <SuccessPanel run={run} bugs={bugs} />}
+      {run?.status === 'failed'    && <FailurePanel run={run} />}
+
+      {/* Pages explored with screenshots — shown for completed and failed */}
+      {(run?.status === 'completed' || run?.status === 'failed') && (
+        <PagesExplored
+          summary={run.summary}
+          accentColor={run.status === 'failed' ? 'var(--error)' : '#16a34a'}
+        />
+      )}
+
+      {/* Generated feature file */}
       {featureContent && (
         <div style={{ marginBottom: '1.5rem', background: 'var(--surface-container-low)', borderRadius: '12px', overflow: 'hidden', border: '1px solid var(--outline-variant)' }}>
           <div style={{ padding: '10px 16px', display: 'flex', alignItems: 'center', gap: '8px', borderBottom: '1px solid var(--outline-variant)' }}>
             <span className="material-symbols-outlined" style={{ fontSize: '16px', color: '#16a34a', fontVariationSettings: "'FILL' 1" }}>description</span>
             <span style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--on-surface)', flex: 1 }}>{featureFilename}</span>
             <button onClick={handleDownload} style={{ display: 'flex', alignItems: 'center', gap: '4px', padding: '4px 12px', borderRadius: '6px', fontSize: '0.75rem', fontWeight: 600, background: '#16a34a', color: '#fff', border: 'none', cursor: 'pointer' }}>
-              <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>download</span>
-              Download
+              <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>download</span>Download
             </button>
             <button onClick={() => setFeatureContent(null)} style={{ background: 'none', border: 'none', color: 'var(--outline)', cursor: 'pointer', fontSize: '18px', lineHeight: 1 }}>×</button>
           </div>
@@ -301,17 +650,21 @@ export default function BugReports() {
         </div>
       )}
 
+      {/* Screenshots gallery */}
+      {bugs.length > 0 && <ScreenshotsGallery bugs={filtered} />}
+
       {/* Severity filter pills */}
-      <div style={{ display: 'flex', gap: '8px', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '1.25rem', flexWrap: 'wrap', alignItems: 'center' }}>
+        <span style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Filter:</span>
         {FILTERS.map(f => {
-          const isActive = filter === f;
+          const active = filter === f;
           const sev = SEVERITY_CONFIG[f];
           return (
             <button key={f} onClick={() => setFilter(f)} style={{
-              padding: '6px 14px', borderRadius: '999px', fontSize: '0.8rem', fontWeight: isActive ? 600 : 500,
-              border: isActive ? 'none' : '1px solid var(--outline-variant)',
-              background: isActive ? (sev ? sev.bg : 'var(--primary)') : 'transparent',
-              color: isActive ? (sev ? sev.color : '#fff') : 'var(--on-surface-variant)',
+              padding: '6px 14px', borderRadius: '999px', fontSize: '0.8rem', fontWeight: active ? 600 : 500,
+              border: active ? 'none' : '1px solid var(--outline-variant)',
+              background: active ? (sev ? sev.bg : 'var(--primary)') : 'transparent',
+              color: active ? (sev ? sev.color : '#fff') : 'var(--on-surface-variant)',
               cursor: 'pointer',
             }}>
               {f === 'all' ? `All (${bugs.length})` : `${f.charAt(0).toUpperCase() + f.slice(1)} (${countBySev(f)})`}
@@ -324,13 +677,13 @@ export default function BugReports() {
       {filtered.length === 0 ? (
         <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '12px', padding: '4rem', textAlign: 'center', color: 'var(--on-surface-variant)' }}>
           <span className="material-symbols-outlined" style={{ fontSize: '48px', color: 'var(--outline-variant)', display: 'block', marginBottom: '12px' }}>verified</span>
-          <p style={{ fontWeight: 500, color: 'var(--on-surface)', marginBottom: '4px' }}>{filter === 'all' ? (isActive ? 'Run in progress — bugs will appear here' : 'No bugs found!') : `No ${filter} severity bugs`}</p>
+          <p style={{ fontWeight: 500, color: 'var(--on-surface)', marginBottom: '4px' }}>
+            {filter === 'all' ? (isActive ? 'Run in progress — bugs will appear here' : 'No bugs found!') : `No ${filter} severity bugs`}
+          </p>
           {filter !== 'all' && <p style={{ fontSize: '0.875rem' }}>Try selecting a different filter.</p>}
         </div>
       ) : (
-        <div>
-          {filtered.map(bug => <BugCard key={bug.id} bug={bug} onStatusChange={handleStatusChange} />)}
-        </div>
+        <div>{filtered.map(bug => <BugCard key={bug.id} bug={bug} onStatusChange={handleStatusChange} />)}</div>
       )}
     </div>
   );

--- a/frontend/src/components/BugReports.jsx
+++ b/frontend/src/components/BugReports.jsx
@@ -2,8 +2,11 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { formatDistanceToNow, format } from 'date-fns';
 import api from '../services/api.js';
+import { EVENT_CONFIG } from '../data/liveEventConfig.js';
+import AgentPipelineTracker from './AgentPipelineTracker.jsx';
+import AgentActivityLog from './AgentActivityLog.jsx';
 
-const ACTIVE_STATUSES = new Set(['pending', 'running']);
+const ACTIVE_STATUSES = new Set(['pending', 'running', 'paused']);
 
 const SEVERITY_CONFIG = {
   critical: { bg: 'var(--error-container)', color: 'var(--error)',                rail: 'var(--error)',                icon: 'crisis_alert' },
@@ -13,19 +16,10 @@ const SEVERITY_CONFIG = {
 };
 
 const STATUS_CONFIG = {
-  open:      { bg: 'rgba(0,88,190,0.08)', color: 'var(--secondary)' },
+  open:      { bg: 'var(--secondary-soft)', color: 'var(--secondary)' },
   confirmed: { bg: '#ede9fe',             color: '#5b21b6' },
   fixed:     { bg: '#f0fdf4',             color: '#16a34a' },
   wontfix:   { bg: 'var(--surface-container-high)', color: 'var(--on-surface-variant)' },
-};
-
-const EVENT_CONFIG = {
-  agent_start:  { color: 'var(--secondary)', icon: 'play_circle' },
-  agent_done:   { color: '#16a34a',          icon: 'check_circle' },
-  page_visited: { color: 'var(--outline)',   icon: 'travel_explore' },
-  bug_found:    { color: 'var(--error)',     icon: 'bug_report' },
-  run_complete: { color: '#16a34a',          icon: 'verified' },
-  run_failed:   { color: 'var(--error)',     icon: 'error' },
 };
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -119,20 +113,26 @@ function RunOverviewCard({ run, bugs }) {
   const sevCounts = { critical: 0, high: 0, medium: 0, low: 0 };
   bugs.forEach(b => { if (sevCounts[b.severity] !== undefined) sevCounts[b.severity]++; });
   const dur = duration(run.started_at, run.completed_at);
-  const isCompleted = run.status === 'completed';
-  const isFailed    = run.status === 'failed';
-  const isActive    = ACTIVE_STATUSES.has(run.status);
+  const isCompleted  = run.status === 'completed';
+  const isFailed     = run.status === 'failed';
+  const isCancelled  = run.status === 'cancelled';
+  const isPaused     = run.status === 'paused';
+  const isActive     = ACTIVE_STATUSES.has(run.status);
 
   const statusStyle = isCompleted
-    ? { bg: '#f0fdf4', color: '#16a34a', icon: 'verified', label: 'Completed' }
+    ? { bg: '#f0fdf4',                   color: '#16a34a',        icon: 'verified',     label: 'Completed',  bar: '#22c55e' }
     : isFailed
-    ? { bg: 'var(--error-container)', color: 'var(--error)', icon: 'error', label: 'Failed' }
-    : { bg: 'rgba(0,88,190,0.08)', color: 'var(--secondary)', icon: 'autorenew', label: run.status.toUpperCase() };
+    ? { bg: 'var(--error-container)',     color: 'var(--error)',   icon: 'error',        label: 'Failed',     bar: 'var(--error)' }
+    : isCancelled
+    ? { bg: '#fef3c7',                   color: '#92400e',        icon: 'stop_circle',  label: 'Cancelled',  bar: '#d97706' }
+    : isPaused
+    ? { bg: '#ede9fe',                   color: '#5b21b6',        icon: 'pause_circle', label: 'Paused',     bar: '#7c3aed' }
+    : { bg: 'var(--secondary-soft)',      color: 'var(--secondary)', icon: 'autorenew', label: 'Running…',   bar: 'var(--secondary)' };
 
   return (
     <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '12px', marginBottom: '1.5rem', overflow: 'hidden', border: '1px solid rgba(197,198,207,0.15)' }}>
       {/* Status bar */}
-      <div style={{ height: '4px', background: isCompleted ? '#22c55e' : isFailed ? 'var(--error)' : 'var(--secondary)' }} />
+      <div style={{ height: '4px', background: statusStyle.bar }} />
 
       <div style={{ padding: '1.25rem 1.5rem' }}>
         {/* Top row */}
@@ -197,12 +197,16 @@ function PagesExplored({ summary, accentColor = '#16a34a' }) {
   if (pages.length === 0) return null;
 
   const ACTION_LABELS = {
-    observe:                'Analysed page for test opportunities',
-    login_attempt:          'Attempted login',
-    login_flow_completed:   'Login flow completed',
-    login_flow_failed:      'Login flow failed',
-    errors_detected:        'Console / network errors detected',
-    error:                  'Error encountered',
+    observe:                  'Analysed page for test opportunities',
+    login_attempt:            'Attempted login',
+    login_flow_completed:     'Login flow completed',
+    login_flow_failed:        'Login flow failed',
+    smart_login_completed:    'Smart login succeeded',
+    smart_login_partial:      'Smart login reached max steps',
+    smart_login_failed:       'Smart login failed',
+    memory_login_completed:   'Memory-based login succeeded (stored steps)',
+    errors_detected:          'Console / network errors detected',
+    error:                    'Error encountered',
   };
 
   return (
@@ -251,6 +255,29 @@ function PagesExplored({ summary, accentColor = '#16a34a' }) {
                       onClick={e => e.stopPropagation()}
                       style={{ color: accentColor, textDecoration: 'none' }}>{page.url}</a>
                   </div>
+                  {/* Metric chips */}
+                  <div style={{ display: 'flex', gap: '5px', flexWrap: 'wrap', marginTop: '4px' }}>
+                    {page.load_time_ms > 0 && (
+                      <span style={{ fontSize: '10px', padding: '1px 7px', borderRadius: '999px',
+                        background: page.load_time_ms > 3000 ? '#ffedd5' : '#f0fdf4',
+                        color: page.load_time_ms > 3000 ? '#9a3412' : '#15803d', fontWeight: 600 }}>
+                        ⏱ {page.load_time_ms}ms
+                      </span>
+                    )}
+                    {page.links_found > 0 && (
+                      <span style={{ fontSize: '10px', padding: '1px 7px', borderRadius: '999px',
+                        background: 'var(--surface-container-low)', color: 'var(--on-surface-variant)', fontWeight: 600 }}>
+                        🔗 {page.links_found} links
+                      </span>
+                    )}
+                    {page.api_call_count > 0 && (
+                      <span style={{ fontSize: '10px', padding: '1px 7px', borderRadius: '999px',
+                        background: page.api_error_count > 0 ? 'var(--error-container)' : 'var(--surface-container-low)',
+                        color: page.api_error_count > 0 ? 'var(--error)' : 'var(--on-surface-variant)', fontWeight: 600 }}>
+                        {page.api_error_count > 0 ? `⚠ ${page.api_error_count} API errors` : `⚡ ${page.api_call_count} API calls`}
+                      </span>
+                    )}
+                  </div>
                 </div>
 
                 <span className="material-symbols-outlined" style={{ color: 'var(--outline)', fontSize: '18px', flexShrink: 0 }}>
@@ -269,6 +296,39 @@ function PagesExplored({ summary, accentColor = '#16a34a' }) {
                     </div>
                   )}
 
+                  {page.login_steps?.length > 0 && (
+                    <div style={{ marginTop: '12px' }}>
+                      <div style={{ fontSize: '0.7rem', fontWeight: 700, color: '#92400e', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+                        <span className="material-symbols-outlined" style={{ fontSize: '13px' }}>key</span>
+                        Login Steps ({page.login_steps.length})
+                      </div>
+                      <div style={{ display: 'flex', gap: '10px', overflowX: 'auto', paddingBottom: '4px' }}>
+                        {page.login_steps.map((ls, li) => {
+                          const src = ls.screenshot_file ? `/screenshots/${ls.screenshot_file}` : null;
+                          return (
+                            <div key={li} style={{ flexShrink: 0, width: '140px' }}>
+                              {src ? (
+                                <div onClick={() => setLightbox({ src, label: `Login step ${ls.step}: ${ls.action}` })}
+                                  style={{ cursor: 'zoom-in', borderRadius: '6px', overflow: 'hidden', border: '1px solid #fde68a', marginBottom: '5px', height: '88px', background: 'var(--surface-container-low)', position: 'relative' }}>
+                                  <img src={src} alt={`step ${ls.step}`} style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+                                  <div style={{ position: 'absolute', top: '4px', left: '4px', background: '#92400e', color: '#fff', borderRadius: '3px', padding: '1px 5px', fontSize: '10px', fontWeight: 700 }}>
+                                    {ls.step}
+                                  </div>
+                                </div>
+                              ) : (
+                                <div style={{ borderRadius: '6px', border: '1px dashed #fde68a', marginBottom: '5px', height: '88px', background: 'var(--surface-container-low)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                                  <span className="material-symbols-outlined" style={{ fontSize: '20px', color: 'var(--outline-variant)' }}>image_not_supported</span>
+                                </div>
+                              )}
+                              <div style={{ fontSize: '0.68rem', color: '#92400e', fontWeight: 600, textTransform: 'capitalize' }}>{ls.action}</div>
+                              <div style={{ fontSize: '0.65rem', color: 'var(--outline)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontFamily: 'monospace' }}>{ls.selector}</div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+
                   {page.steps?.length > 0 && (
                     <div style={{ marginTop: '12px' }}>
                       <div style={{ fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px' }}>
@@ -277,8 +337,8 @@ function PagesExplored({ summary, accentColor = '#16a34a' }) {
                       <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
                         {page.steps.map((step, si) => (
                           <div key={si} style={{ display: 'flex', gap: '8px', fontSize: '0.8rem', alignItems: 'flex-start' }}>
-                            <span className="material-symbols-outlined" style={{ fontSize: '14px', color: step.action === 'error' || step.action === 'login_flow_failed' ? 'var(--error)' : accentColor, flexShrink: 0, marginTop: '1px' }}>
-                              {step.action === 'observe' ? 'search' : step.action.includes('login') ? 'key' : step.action === 'errors_detected' ? 'warning' : 'info'}
+                            <span className="material-symbols-outlined" style={{ fontSize: '14px', color: step.action === 'error' || step.action?.includes('failed') ? 'var(--error)' : accentColor, flexShrink: 0, marginTop: '1px' }}>
+                              {step.action === 'observe' ? 'search' : step.action?.includes('login') ? 'key' : step.action === 'errors_detected' ? 'warning' : 'info'}
                             </span>
                             <div>
                               <span style={{ fontWeight: 500, color: 'var(--on-surface)' }}>{ACTION_LABELS[step.action] || step.action}</span>
@@ -299,6 +359,75 @@ function PagesExplored({ summary, accentColor = '#16a34a' }) {
       </div>
 
       {lightbox && <Lightbox src={lightbox.src} label={lightbox.label} onClose={() => setLightbox(null)} />}
+    </div>
+  );
+}
+
+// ─── Test Execution Summary ───────────────────────────────────────────────────
+
+function TestExecutionSummary({ run }) {
+  const summary = run.summary || {};
+  const plan = summary.strategic_plan || {};
+  const plannedPages = (plan.pages || []).length;
+  const testedPages  = summary.pages_explored || 0;
+  const suggestions  = summary.improvement_suggestions || [];
+
+  if (!testedPages) return null;
+
+  const stats = [
+    { label: 'Pages Planned', value: plannedPages || '—', icon: 'map' },
+    { label: 'Pages Tested',  value: testedPages,          icon: 'travel_explore' },
+    { label: 'Avg Load Time', value: summary.avg_load_time_ms ? `${summary.avg_load_time_ms}ms` : '—', icon: 'timer' },
+    { label: 'Links Found',   value: summary.total_links_found ?? '—', icon: 'link' },
+    { label: 'API Calls',     value: summary.total_api_calls ?? '—', icon: 'cloud' },
+    { label: 'API Errors',    value: summary.api_error_count ?? '—', icon: 'error_outline', highlight: summary.api_error_count > 0 },
+  ];
+
+  return (
+    <div style={{ marginBottom: '1.5rem', background: 'var(--surface-container-lowest)',
+      border: '1px solid rgba(197,198,207,0.15)', borderRadius: '12px', overflow: 'hidden' }}>
+      <div style={{ padding: '10px 14px', borderBottom: '1px solid var(--surface-container-low)',
+        fontSize: '0.7rem', fontWeight: 700, color: 'var(--on-surface-variant)',
+        textTransform: 'uppercase', letterSpacing: '0.08em', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>analytics</span>
+        Test Execution Summary
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(130px, 1fr))', gap: '1px',
+        background: 'var(--surface-container-low)' }}>
+        {stats.map(({ label, value, icon, highlight }) => (
+          <div key={label} style={{ padding: '12px 14px', background: 'var(--surface-container-lowest)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '4px' }}>
+              <span className="material-symbols-outlined"
+                style={{ fontSize: '13px', color: highlight ? 'var(--error)' : 'var(--on-surface-variant)' }}>{icon}</span>
+              <span style={{ fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em',
+                color: highlight ? 'var(--error)' : 'var(--on-surface-variant)' }}>{label}</span>
+            </div>
+            <div style={{ fontSize: '1.1rem', fontWeight: 700,
+              color: highlight ? 'var(--error)' : 'var(--on-surface)' }}>{value}</div>
+          </div>
+        ))}
+      </div>
+
+      {suggestions.length > 0 && (
+        <div style={{ padding: '12px 14px', borderTop: '1px solid var(--surface-container-low)' }}>
+          <div style={{ fontSize: '0.7rem', fontWeight: 700, color: '#92400e',
+            textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px',
+            display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <span className="material-symbols-outlined" style={{ fontSize: '13px' }}>lightbulb</span>
+            Improvement Suggestions
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            {suggestions.map((s, i) => (
+              <div key={i} style={{ display: 'flex', gap: '8px', fontSize: '0.8rem',
+                color: 'var(--on-surface)', alignItems: 'flex-start' }}>
+                <span style={{ color: '#d97706', flexShrink: 0, marginTop: '1px' }}>•</span>
+                {s}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -462,10 +591,11 @@ function BugCard({ bug, onStatusChange }) {
 
 function LiveActivityPanel({ events }) {
   const bottomRef = useRef(null);
+  const [lightbox, setLightbox] = useState(null);
   useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [events]);
 
   return (
-    <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '10px', padding: '1rem', maxHeight: '240px', overflowY: 'auto', fontFamily: 'monospace', fontSize: '0.78rem' }}>
+    <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '10px', padding: '1rem', maxHeight: '380px', overflowY: 'auto', fontFamily: 'monospace', fontSize: '0.78rem' }}>
       {events.length === 0 && (
         <div style={{ color: 'var(--outline)', display: 'flex', alignItems: 'center', gap: '8px' }}>
           <span className="material-symbols-outlined pulse" style={{ fontSize: '16px', color: 'var(--secondary)' }}>autorenew</span>
@@ -474,14 +604,28 @@ function LiveActivityPanel({ events }) {
       )}
       {events.map((ev, i) => {
         const cfg = EVENT_CONFIG[ev.type] || { color: 'var(--outline)', icon: 'info' };
+        const screenshotSrc = ev.screenshot_file ? `/screenshots/${ev.screenshot_file}` : null;
         return (
-          <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '6px', color: cfg.color }}>
-            <span className="material-symbols-outlined" style={{ fontSize: '14px', flexShrink: 0, marginTop: '1px', fontVariationSettings: "'FILL' 1" }}>{cfg.icon}</span>
-            <span style={{ lineHeight: 1.4, wordBreak: 'break-word' }}>{ev.message || ev.type}</span>
+          <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '8px', color: cfg.color }}>
+            <span className="material-symbols-outlined" style={{ fontSize: '14px', flexShrink: 0, marginTop: '2px', fontVariationSettings: "'FILL' 1" }}>{cfg.icon}</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <span style={{ lineHeight: 1.4, wordBreak: 'break-word' }}>{ev.message || ev.type}</span>
+              {screenshotSrc && (
+                <div style={{ marginTop: '5px' }}>
+                  <img
+                    src={screenshotSrc}
+                    alt={ev.message}
+                    onClick={() => setLightbox({ src: screenshotSrc, label: ev.message })}
+                    style={{ height: '64px', borderRadius: '5px', border: '1px solid rgba(197,198,207,0.4)', objectFit: 'cover', cursor: 'zoom-in', display: 'block' }}
+                  />
+                </div>
+              )}
+            </div>
           </div>
         );
       })}
       <div ref={bottomRef} />
+      {lightbox && <Lightbox src={lightbox.src} label={lightbox.label} onClose={() => setLightbox(null)} />}
     </div>
   );
 }
@@ -495,11 +639,18 @@ export default function BugReports() {
   const [filter, setFilter]   = useState('all');
   const [loading, setLoading] = useState(true);
   const [error, setError]     = useState(null);
-  const [liveEvents, setLiveEvents]   = useState([]);
-  const [showLive, setShowLive]       = useState(true);
+  const [liveEvents, setLiveEvents] = useState(() => {
+    try {
+      const stored = localStorage.getItem(`bughunter_events_${id}`);
+      return stored ? JSON.parse(stored) : [];
+    } catch { return []; }
+  });
+  const [showLive, setShowLive] = useState(true);
+  const [showAgentLogs, setShowAgentLogs] = useState(true);
   const [generating, setGenerating]   = useState(false);
   const [featureContent, setFeatureContent]   = useState(null);
   const [featureFilename, setFeatureFilename] = useState('regression.feature');
+  const [controlLoading, setControlLoading] = useState(null); // 'stop' | 'pause' | 'resume' | null
   const sseRef  = useRef(null);
   const pollRef = useRef(null);
 
@@ -512,17 +663,28 @@ export default function BugReports() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  // SSE while active; polling fallback
+  // SSE while running; polling fallback and when paused
   useEffect(() => {
     const isActive = run && ACTIVE_STATUSES.has(run.status);
-    if (isActive && !sseRef.current) {
+    const isPaused = run?.status === 'paused';
+    // Use SSE only when actually running (not paused — agent sends no events while paused)
+    if (isActive && !isPaused && !sseRef.current) {
       const token = localStorage.getItem('bughunter_token');
       const sse = new EventSource(`/api/runs/${id}/stream?token=${token}`);
       sseRef.current = sse;
       sse.onmessage = (e) => {
         try {
-          const event = JSON.parse(e.data);
-          setLiveEvents(prev => [...prev, event]);
+          const event = { ...JSON.parse(e.data), clientTs: Date.now() };
+          setLiveEvents(prev => {
+            const next = [...prev, event];
+            try {
+              localStorage.setItem(
+                `bughunter_events_${id}`,
+                JSON.stringify(next.slice(-500))
+              );
+            } catch { /* storage full — ignore */ }
+            return next;
+          });
           if (event.type === 'run_complete' || event.type === 'run_failed') {
             setTimeout(fetchData, 1000);
           }
@@ -532,6 +694,10 @@ export default function BugReports() {
         sse.close(); sseRef.current = null;
         if (!pollRef.current) pollRef.current = setInterval(fetchData, 5000);
       };
+    }
+    // Poll while paused (agent not sending SSE events) so we detect resume/stop
+    if (isPaused && !pollRef.current) {
+      pollRef.current = setInterval(fetchData, 3000);
     }
     if (!isActive) {
       if (sseRef.current) { sseRef.current.close(); sseRef.current = null; }
@@ -557,6 +723,36 @@ export default function BugReports() {
     } catch (err) {
       setError(err.response?.data?.error || err.message || 'Failed to generate tests');
     } finally { setGenerating(false); }
+  };
+
+  const handleStop = async () => {
+    setControlLoading('stop');
+    try {
+      await api.post(`/runs/${id}/stop`);
+      fetchData();
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Failed to stop run');
+    } finally { setControlLoading(null); }
+  };
+
+  const handlePause = async () => {
+    setControlLoading('pause');
+    try {
+      await api.post(`/runs/${id}/pause`);
+      fetchData();
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Failed to pause run');
+    } finally { setControlLoading(null); }
+  };
+
+  const handleResume = async () => {
+    setControlLoading('resume');
+    try {
+      await api.post(`/runs/${id}/resume`);
+      fetchData();
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Failed to resume run');
+    } finally { setControlLoading(null); }
   };
 
   const handleDownload = () => {
@@ -586,17 +782,66 @@ export default function BugReports() {
           <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-tertiary-container)', textTransform: 'uppercase', letterSpacing: '0.2em', marginBottom: '6px' }}>Vulnerability Report</span>
           <h2 style={{ fontSize: '2.25rem', fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--primary)', marginBottom: '4px' }}>Test Results</h2>
         </div>
-        {run?.status === 'completed' && bugs.length > 0 && (
-          <button onClick={handleGenerateTests} disabled={generating} style={{
-            display: 'flex', alignItems: 'center', gap: '6px',
-            padding: '8px 16px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 600,
-            background: 'var(--primary)', color: '#fff', border: 'none', cursor: generating ? 'wait' : 'pointer',
-            opacity: generating ? 0.7 : 1,
-          }}>
-            <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>science</span>
-            {generating ? 'Generating…' : 'Generate Tests'}
-          </button>
-        )}
+        <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+          {/* Run controls: shown when test is pending or running */}
+          {(run?.status === 'pending' || run?.status === 'running') && (
+            <>
+              {run?.status === 'running' && (
+                <button onClick={handlePause} disabled={!!controlLoading} style={{
+                  display: 'flex', alignItems: 'center', gap: '5px',
+                  padding: '8px 14px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 600,
+                  background: '#ede9fe', color: '#5b21b6', border: '1px solid #c4b5fd',
+                  cursor: controlLoading ? 'wait' : 'pointer', opacity: controlLoading ? 0.7 : 1,
+                }}>
+                  <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>pause</span>
+                  {controlLoading === 'pause' ? 'Pausing…' : 'Pause'}
+                </button>
+              )}
+              <button onClick={handleStop} disabled={!!controlLoading} style={{
+                display: 'flex', alignItems: 'center', gap: '5px',
+                padding: '8px 14px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 600,
+                background: 'var(--error-container)', color: 'var(--error)', border: '1px solid var(--error)',
+                cursor: controlLoading ? 'wait' : 'pointer', opacity: controlLoading ? 0.7 : 1,
+              }}>
+                <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>stop</span>
+                {controlLoading === 'stop' ? 'Stopping…' : 'Stop'}
+              </button>
+            </>
+          )}
+          {run?.status === 'paused' && (
+            <>
+              <button onClick={handleResume} disabled={!!controlLoading} style={{
+                display: 'flex', alignItems: 'center', gap: '5px',
+                padding: '8px 14px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 600,
+                background: '#f0fdf4', color: '#16a34a', border: '1px solid #86efac',
+                cursor: controlLoading ? 'wait' : 'pointer', opacity: controlLoading ? 0.7 : 1,
+              }}>
+                <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>play_arrow</span>
+                {controlLoading === 'resume' ? 'Resuming…' : 'Resume'}
+              </button>
+              <button onClick={handleStop} disabled={!!controlLoading} style={{
+                display: 'flex', alignItems: 'center', gap: '5px',
+                padding: '8px 14px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 600,
+                background: 'var(--error-container)', color: 'var(--error)', border: '1px solid var(--error)',
+                cursor: controlLoading ? 'wait' : 'pointer', opacity: controlLoading ? 0.7 : 1,
+              }}>
+                <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>stop</span>
+                {controlLoading === 'stop' ? 'Stopping…' : 'Stop'}
+              </button>
+            </>
+          )}
+          {run?.status === 'completed' && bugs.length > 0 && (
+            <button onClick={handleGenerateTests} disabled={generating} style={{
+              display: 'flex', alignItems: 'center', gap: '6px',
+              padding: '8px 16px', borderRadius: '8px', fontSize: '0.8rem', fontWeight: 600,
+              background: 'var(--primary)', color: '#fff', border: 'none', cursor: generating ? 'wait' : 'pointer',
+              opacity: generating ? 0.7 : 1,
+            }}>
+              <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>science</span>
+              {generating ? 'Generating…' : 'Generate Tests'}
+            </button>
+          )}
+        </div>
       </div>
 
       {error && (
@@ -609,27 +854,70 @@ export default function BugReports() {
       {/* Run overview */}
       {run && <RunOverviewCard run={run} bugs={bugs} />}
 
-      {/* Live activity — while running */}
-      {isActive && (
-        <div style={{ marginBottom: '1.5rem', background: 'var(--surface-container-low)', borderRadius: '12px', overflow: 'hidden', border: '1px solid var(--outline-variant)' }}>
-          <div onClick={() => setShowLive(!showLive)} style={{ padding: '10px 16px', display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
-            <span className="material-symbols-outlined pulse" style={{ fontSize: '16px', color: 'var(--secondary)' }}>sensors</span>
-            <span style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--on-surface)', flex: 1 }}>Live Activity</span>
-            <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--outline)' }}>{showLive ? 'expand_less' : 'expand_more'}</span>
+      {/* Pipeline + activity + agent logs */}
+      {(isActive || liveEvents.length > 0) && (
+        <div style={{ marginBottom: '1.5rem' }}>
+          <AgentPipelineTracker events={liveEvents} runStatus={run?.status} variant="run" />
+
+          <div style={{ marginBottom: '1rem', background: 'var(--surface-container-low)', borderRadius: '12px', overflow: 'hidden', border: `1px solid ${isActive ? 'var(--secondary)' : 'var(--outline-variant)'}` }}>
+            <div onClick={() => setShowLive(!showLive)} style={{ padding: '10px 16px', display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+              <span className={`material-symbols-outlined${isActive ? ' pulse' : ''}`} style={{ fontSize: '16px', color: isActive ? 'var(--secondary)' : 'var(--outline)' }}>
+                {isActive ? 'sensors' : 'history'}
+              </span>
+              <span style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--on-surface)', flex: 1 }}>
+                {isActive ? 'Live Activity' : 'Activity Log'}
+              </span>
+              <span style={{ fontSize: '0.7rem', color: 'var(--outline)', padding: '2px 8px', background: 'var(--surface-container)', borderRadius: '999px' }}>
+                {liveEvents.length} events
+              </span>
+              <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--outline)', marginLeft: '4px' }}>{showLive ? 'expand_less' : 'expand_more'}</span>
+            </div>
+            {showLive && <div style={{ padding: '0 12px 12px' }}><LiveActivityPanel events={liveEvents} /></div>}
           </div>
-          {showLive && <div style={{ padding: '0 12px 12px' }}><LiveActivityPanel events={liveEvents} /></div>}
+
+          <div style={{ background: 'var(--surface-container-low)', borderRadius: '12px', overflow: 'hidden', border: '1px solid var(--outline-variant)' }}>
+            <div onClick={() => setShowAgentLogs(!showAgentLogs)} style={{ padding: '10px 16px', display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+              <span className="material-symbols-outlined" style={{ fontSize: '16px', color: 'var(--secondary)' }}>hub</span>
+              <span style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--on-surface)', flex: 1 }}>
+                Agent logs
+              </span>
+              <span style={{ fontSize: '0.7rem', color: 'var(--outline)', padding: '2px 8px', background: 'var(--surface-container)', borderRadius: '999px' }}>
+                By agent
+              </span>
+              <span className="material-symbols-outlined" style={{ fontSize: '18px', color: 'var(--outline)', marginLeft: '4px' }}>{showAgentLogs ? 'expand_less' : 'expand_more'}</span>
+            </div>
+            {showAgentLogs && (
+              <div style={{ padding: '0 12px 12px' }}>
+                <AgentActivityLog events={liveEvents} />
+              </div>
+            )}
+          </div>
         </div>
       )}
 
-      {/* Success / Failure panels */}
-      {run?.status === 'completed' && <SuccessPanel run={run} bugs={bugs} />}
-      {run?.status === 'failed'    && <FailurePanel run={run} />}
+      {/* Success / Failure / Cancelled panels */}
+      {run?.status === 'completed'  && <SuccessPanel run={run} bugs={bugs} />}
+      {run?.status === 'failed'     && <FailurePanel run={run} />}
+      {run?.status === 'cancelled'  && (
+        <div style={{ background: '#fef3c7', borderRadius: '12px', padding: '1rem 1.25rem', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '12px', border: '1px solid #fcd34d' }}>
+          <span className="material-symbols-outlined" style={{ color: '#d97706', fontSize: '20px', fontVariationSettings: "'FILL' 1" }}>stop_circle</span>
+          <div>
+            <div style={{ fontWeight: 600, color: '#92400e', marginBottom: '2px' }}>Test run cancelled</div>
+            <div style={{ fontSize: '0.8rem', color: '#b45309' }}>The run was stopped early. Any bugs found before cancellation are shown below.</div>
+          </div>
+        </div>
+      )}
 
-      {/* Pages explored with screenshots — shown for completed and failed */}
-      {(run?.status === 'completed' || run?.status === 'failed') && (
+      {/* Test execution summary — shown for completed, failed, and cancelled */}
+      {['completed', 'failed', 'cancelled'].includes(run?.status) && (
+        <TestExecutionSummary run={run} />
+      )}
+
+      {/* Pages explored with screenshots — shown for completed, failed, and cancelled */}
+      {['completed', 'failed', 'cancelled'].includes(run?.status) && (
         <PagesExplored
           summary={run.summary}
-          accentColor={run.status === 'failed' ? 'var(--error)' : '#16a34a'}
+          accentColor={run.status === 'cancelled' ? '#d97706' : run.status === 'failed' ? 'var(--error)' : '#16a34a'}
         />
       )}
 

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -2,91 +2,288 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
 import api from '../services/api.js';
+import { useAuth } from '../context/AuthContext.jsx';
 
 const STAT_CARDS = [
-  { key: 'apps',     label: 'Total Apps',    icon: 'apps',         accent: 'var(--secondary)' },
-  { key: 'runs',     label: 'Total Runs',    icon: 'flaky',        accent: 'var(--on-tertiary-container)' },
-  { key: 'bugs',     label: 'Bugs Detected', icon: 'pest_control', accent: 'var(--outline)' },
-  { key: 'critical', label: 'Critical',      icon: 'warning',      accent: 'var(--error)' },
+  { key: 'apps', label: 'Total Apps', icon: 'apps', accent: 'var(--secondary)', to: '/apps', appQuery: false },
+  { key: 'runs', label: 'Total Runs', icon: 'flaky', accent: 'var(--on-tertiary-container)', to: '/runs', appQuery: true },
+  { key: 'bugs', label: 'Bugs Detected', icon: 'pest_control', accent: 'var(--outline)', to: '/bugs', appQuery: true },
+  {
+    key: 'critical',
+    label: 'Critical',
+    icon: 'warning',
+    accent: 'var(--error)',
+    to: '/bugs',
+    appQuery: true,
+    extraSearch: { severity: 'critical' },
+  },
 ];
 
+function buildTileTo(path, appId, extraSearch = {}) {
+  const params = new URLSearchParams();
+  if (appId) params.set('app_id', appId);
+  Object.entries(extraSearch).forEach(([k, v]) => {
+    if (v != null && v !== '') params.set(k, String(v));
+  });
+  const q = params.toString();
+  return q ? `${path}?${q}` : path;
+}
+
 const STATUS_BADGE = {
-  pending:   { bg: '#fef3c7', color: '#92400e' },
-  running:   { bg: 'rgba(0,88,190,0.08)', color: 'var(--secondary)' },
+  pending: { bg: '#fef3c7', color: '#92400e' },
+  running: { bg: 'var(--secondary-soft)', color: 'var(--secondary)' },
   completed: { bg: '#f0fdf4', color: '#16a34a' },
-  failed:    { bg: 'var(--error-container)', color: 'var(--error)' },
+  failed: { bg: 'var(--error-container)', color: 'var(--error)' },
 };
 
 export default function Dashboard() {
+  const { user } = useAuth();
   const [stats, setStats] = useState({ apps: 0, runs: 0, bugs: 0, critical: 0 });
   const [recentRuns, setRecentRuns] = useState([]);
+  const [appsList, setAppsList] = useState([]);
+  const [selectedAppId, setSelectedAppId] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   const fetchData = useCallback(() => {
+    setLoading(true);
+    const appParam = selectedAppId ? `&app_id=${encodeURIComponent(selectedAppId)}` : '';
     Promise.all([
       api.get('/apps'),
-      api.get('/runs?limit=5'),
-      api.get('/bugs?limit=1'),
-      api.get('/bugs?severity=critical&limit=1'),
-    ]).then(([appsRes, runsRes, bugsRes, criticalRes]) => {
-      setStats({
-        apps:     appsRes.data.apps?.length || 0,
-        runs:     runsRes.data.total ?? runsRes.data.runs?.length ?? 0,
-        bugs:     bugsRes.data.total ?? bugsRes.data.bugs?.length ?? 0,
-        critical: criticalRes.data.total ?? criticalRes.data.bugs?.filter(b => b.severity === 'critical').length ?? 0,
-      });
-      setRecentRuns(runsRes.data.runs || []);
-      setError(null);
-    }).catch(err => {
-      setError(err.response?.data?.error || err.message || 'Failed to load dashboard');
-    }).finally(() => setLoading(false));
-  }, []);
+      api.get(`/runs?limit=5${appParam}`),
+      api.get(`/bugs?limit=1${appParam}`),
+      api.get(`/bugs?severity=critical&limit=1${appParam}`),
+    ])
+      .then(([appsRes, runsRes, bugsRes, criticalRes]) => {
+        const apps = appsRes.data.apps || [];
+        setAppsList(apps);
+        setStats({
+          apps: selectedAppId ? 1 : apps.length,
+          runs: runsRes.data.total ?? runsRes.data.runs?.length ?? 0,
+          bugs: bugsRes.data.total ?? bugsRes.data.bugs?.length ?? 0,
+          critical:
+            criticalRes.data.total ??
+            criticalRes.data.bugs?.filter((b) => b.severity === 'critical').length ??
+            0,
+        });
+        setRecentRuns(runsRes.data.runs || []);
+        setError(null);
+      })
+      .catch((err) => {
+        setError(err.response?.data?.error || err.message || 'Failed to load dashboard');
+      })
+      .finally(() => setLoading(false));
+  }, [selectedAppId]);
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
-  if (loading) return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--on-surface-variant)', padding: '2rem 0' }}>
-      <span className="material-symbols-outlined pulse" style={{ color: 'var(--secondary)' }}>autorenew</span>
-      Loading dashboard...
-    </div>
-  );
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--on-surface-variant)', padding: '2rem 0' }}>
+        <span className="material-symbols-outlined pulse" style={{ color: 'var(--link)' }}>
+          autorenew
+        </span>
+        Loading dashboard...
+      </div>
+    );
+  }
+
+  const firstName = (user?.name || user?.email || 'there').split(/\s+/)[0];
 
   return (
     <div>
-      {/* Page header */}
-      <div style={{ marginBottom: '2.5rem' }}>
-        <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--secondary)', textTransform: 'uppercase', letterSpacing: '0.2em', marginBottom: '6px' }}>System Overview</span>
-        <h2 style={{ fontSize: '2.25rem', fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--primary)' }}>Operational Intelligence</h2>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <h1 style={{ fontSize: '1.75rem', fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--primary)', marginBottom: '6px' }}>
+          Hi, {firstName}.
+        </h1>
+        <p style={{ fontSize: '0.9375rem', color: 'var(--on-surface-variant)', maxWidth: '520px' }}>
+          Access security testing and audit results for your applications in one place.
+        </p>
+      </div>
+
+      <div className="info-banner" role="status">
+        <span className="material-symbols-outlined info-banner__icon">info</span>
+        <span>
+          Test runs execute autonomous browser exploration against your registered apps. Critical findings appear in bug reports with evidence and screenshots.
+        </span>
+      </div>
+
+      <div style={{ marginBottom: '2rem' }}>
+        <span
+          style={{
+            display: 'block',
+            fontSize: '11px',
+            fontWeight: 700,
+            color: 'var(--on-surface-variant)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.14em',
+            marginBottom: '6px',
+          }}
+        >
+          System overview
+        </span>
+        <h2 style={{ fontSize: '1.25rem', fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--primary)' }}>Operational intelligence</h2>
       </div>
 
       {error && (
-        <div style={{ background: 'var(--error-container)', color: 'var(--error)', padding: '12px 16px', borderRadius: '8px', marginBottom: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.875rem' }}>
+        <div
+          style={{
+            background: 'var(--error-container)',
+            color: 'var(--error)',
+            padding: '12px 16px',
+            borderRadius: '8px',
+            marginBottom: '1.5rem',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: '0.875rem',
+          }}
+        >
           <span>{error}</span>
-          <button onClick={() => { setError(null); fetchData(); }} style={{ background: 'none', border: 'none', color: 'var(--error)', fontWeight: 600 }}>Retry</button>
+          <button
+            type="button"
+            onClick={() => {
+              setError(null);
+              fetchData();
+            }}
+            style={{ background: 'none', border: 'none', color: 'var(--error)', fontWeight: 600 }}
+          >
+            Retry
+          </button>
         </div>
       )}
 
+      <div
+        style={{
+          marginBottom: '1rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px',
+          flexWrap: 'wrap',
+        }}
+      >
+        <label
+          htmlFor="dashboard-app-filter"
+          style={{
+            fontSize: '0.7rem',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: 'var(--on-surface-variant)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+          }}
+        >
+          Filter by app
+          <select
+            id="dashboard-app-filter"
+            value={selectedAppId}
+            onChange={(e) => {
+              setLoading(true);
+              setSelectedAppId(e.target.value);
+            }}
+            className="ent-input"
+            style={{
+              minWidth: '220px',
+              padding: '8px 12px',
+              borderRadius: '8px',
+              fontSize: '0.875rem',
+              border: '1px solid var(--border-subtle)',
+              background: 'var(--surface-container-lowest)',
+              color: 'var(--on-surface)',
+            }}
+          >
+            <option value="">All apps</option>
+            {appsList.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name || a.url || a.id}
+              </option>
+            ))}
+          </select>
+        </label>
+        {selectedAppId && (
+          <span style={{ fontSize: '0.8rem', color: 'var(--on-surface-variant)' }}>Metrics below reflect this app only.</span>
+        )}
+      </div>
+
       {/* KPI grid */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '1.25rem', marginBottom: '2.5rem' }}>
-        {STAT_CARDS.map(({ key, label, icon, accent }) => (
-          <div key={key} style={{ background: 'var(--surface-container-lowest)', borderRadius: '12px', padding: '1.5rem', borderLeft: `4px solid ${accent}` }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1rem' }}>
-              <span style={{ fontSize: '11px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>{label}</span>
-              <span className="material-symbols-outlined" style={{ color: accent, fontSize: '20px', fontVariationSettings: key === 'critical' ? "'FILL' 1" : undefined }}>{icon}</span>
-            </div>
-            <div style={{ fontSize: '2.5rem', fontWeight: 300, letterSpacing: '-0.03em', color: key === 'critical' && stats[key] > 0 ? 'var(--error)' : 'var(--primary)' }}>
-              {stats[key]}
-            </div>
-          </div>
-        ))}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          gap: '1.25rem',
+          marginBottom: '2.5rem',
+        }}
+      >
+        {STAT_CARDS.map(({ key, label, icon, accent, to, appQuery, extraSearch }) => {
+          const linkTo = appQuery ? buildTileTo(to, selectedAppId, extraSearch || {}) : to;
+          return (
+            <Link
+              key={key}
+              to={linkTo}
+              className="hoverable-card dashboard-kpi-tile"
+              style={{
+                background: 'var(--surface-container-lowest)',
+                borderRadius: '8px',
+                padding: '1.5rem',
+                border: '1px solid var(--border-subtle)',
+                borderLeft: `4px solid ${accent}`,
+                textDecoration: 'none',
+                color: 'inherit',
+                display: 'block',
+                transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+              }}
+              aria-label={`${label}: ${stats[key]}. Open details.`}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1rem' }}>
+                <span
+                  style={{
+                    fontSize: '11px',
+                    fontWeight: 700,
+                    color: 'var(--on-surface-variant)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.08em',
+                  }}
+                >
+                  {label}
+                </span>
+                <span
+                  className="material-symbols-outlined"
+                  style={{ color: accent, fontSize: '20px', fontVariationSettings: key === 'critical' ? "'FILL' 1" : undefined }}
+                  aria-hidden
+                >
+                  {icon}
+                </span>
+              </div>
+              <div
+                style={{
+                  fontSize: '2.5rem',
+                  fontWeight: 300,
+                  letterSpacing: '-0.03em',
+                  color: key === 'critical' && stats[key] > 0 ? 'var(--error)' : 'var(--primary)',
+                }}
+              >
+                {stats[key]}
+              </div>
+              <div style={{ marginTop: '10px', fontSize: '0.75rem', fontWeight: 600, color: 'var(--link)', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                View details
+                <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>
+                  arrow_forward
+                </span>
+              </div>
+            </Link>
+          );
+        })}
       </div>
 
       {/* Recent runs */}
-      <div style={{ background: 'var(--surface-container-low)', borderRadius: '16px', padding: '8px' }}>
+      <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', padding: '8px', border: '1px solid var(--border-subtle)' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '1rem 1.25rem 0.75rem' }}>
-          <h3 style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.12em' }}>Recent Test Runs</h3>
-          <Link to="/runs" style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--secondary)', display: 'flex', alignItems: 'center', gap: '4px' }}>
+          <h3 style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--on-surface)', textTransform: 'uppercase', letterSpacing: '0.12em' }}>Recent test runs</h3>
+          <Link to={buildTileTo('/runs', selectedAppId)} style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--link)', display: 'flex', alignItems: 'center', gap: '4px' }}>
             View all <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>arrow_forward</span>
           </Link>
         </div>
@@ -94,29 +291,75 @@ export default function Dashboard() {
         {recentRuns.length === 0 ? (
           <div style={{ padding: '2.5rem', textAlign: 'center', color: 'var(--on-surface-variant)', fontSize: '0.875rem' }}>
             No test runs yet.{' '}
-            <Link to="/runs" style={{ color: 'var(--secondary)', fontWeight: 500 }}>Start one →</Link>
+            <Link to={buildTileTo('/runs', selectedAppId)} style={{ color: 'var(--link)', fontWeight: 500 }}>
+              Start one →
+            </Link>
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', marginTop: '4px' }}>
             {/* Header row */}
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 120px 80px 1fr', padding: '8px 20px', fontSize: '10px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.12em' }}>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 120px 80px 1fr',
+                padding: '10px 20px',
+                fontSize: '10px',
+                fontWeight: 700,
+                color: 'var(--on-surface)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.12em',
+                background: 'var(--table-header-bg)',
+                borderRadius: '6px 6px 0 0',
+              }}
+            >
               <span>Application</span>
               <span style={{ textAlign: 'center' }}>Status</span>
               <span style={{ textAlign: 'right' }}>Bugs</span>
               <span style={{ paddingLeft: '1.5rem' }}>Started</span>
             </div>
-            {recentRuns.map(run => {
+            {recentRuns.map((run) => {
               const badge = STATUS_BADGE[run.status] || STATUS_BADGE.pending;
               return (
-                <div key={run.id} className="hoverable-card" style={{ display: 'grid', gridTemplateColumns: '1fr 120px 80px 1fr', alignItems: 'center', padding: '14px 20px', background: 'var(--surface-container-lowest)', borderRadius: '10px' }}>
-                  <Link to={`/runs/${run.id}`} style={{ fontWeight: 600, fontSize: '0.875rem', color: 'var(--primary)' }}>{run.app_name || '—'}</Link>
+                <div
+                  key={run.id}
+                  className="hoverable-card"
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 120px 80px 1fr',
+                    alignItems: 'center',
+                    padding: '14px 20px',
+                    background: 'var(--surface-container-lowest)',
+                    borderRadius: '0',
+                    borderBottom: '1px solid var(--border-subtle)',
+                  }}
+                >
+                  <Link to={`/runs/${run.id}`} style={{ fontWeight: 600, fontSize: '0.875rem', color: 'var(--link)' }}>
+                    {run.app_name || '—'}
+                  </Link>
                   <div style={{ display: 'flex', justifyContent: 'center' }}>
-                    <span style={{ padding: '3px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: badge.bg, color: badge.color, display: 'flex', alignItems: 'center', gap: '4px' }}>
-                      {run.status === 'running' && <span className="pulse" style={{ width: '6px', height: '6px', borderRadius: '50%', background: 'var(--secondary)', display: 'inline-block' }} />}
+                    <span
+                      style={{
+                        padding: '3px 10px',
+                        borderRadius: '999px',
+                        fontSize: '10px',
+                        fontWeight: 700,
+                        background: badge.bg,
+                        color: badge.color,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '4px',
+                      }}
+                    >
+                      {run.status === 'running' && (
+                        <span
+                          className="pulse"
+                          style={{ width: '6px', height: '6px', borderRadius: '50%', background: 'var(--link)', display: 'inline-block' }}
+                        />
+                      )}
                       {run.status?.toUpperCase()}
                     </span>
                   </div>
-                  <span style={{ fontSize: '1.1rem', fontWeight: 300, color: 'var(--primary)', textAlign: 'right' }}>{run.bug_count || 0}</span>
+                  <span style={{ fontSize: '1.1rem', fontWeight: 300, color: 'var(--primary)', textAlign: 'right' }}>{Number(run.bug_count ?? 0)}</span>
                   <span style={{ paddingLeft: '1.5rem', fontSize: '0.8rem', color: 'var(--on-surface-variant)' }}>
                     {run.started_at ? formatDistanceToNow(new Date(run.started_at), { addSuffix: true }) : '—'}
                   </span>

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught:', error, errorInfo);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          minHeight: '60vh', padding: '2rem',
+        }}>
+          <div className="glass-card" style={{
+            padding: '2.5rem', borderRadius: '12px', textAlign: 'center',
+            maxWidth: '480px', width: '100%',
+            border: '1px solid var(--border-subtle)',
+            borderLeft: '4px solid var(--error)',
+          }}>
+            <span className="material-symbols-outlined" style={{
+              fontSize: '48px', color: 'var(--error)', marginBottom: '1rem', display: 'block',
+            }}>error</span>
+            <h2 style={{ fontSize: '1.25rem', fontWeight: 600, color: 'var(--on-surface)', marginBottom: '0.5rem' }}>
+              Something went wrong
+            </h2>
+            <p style={{ color: 'var(--on-surface-variant)', fontSize: '0.875rem', marginBottom: '1.5rem' }}>
+              {this.state.error?.message || 'An unexpected error occurred.'}
+            </p>
+            <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center' }}>
+              <button onClick={this.handleReset} className="btn-primary" style={{ padding: '10px 24px', fontSize: '0.875rem' }}>
+                Try Again
+              </button>
+              <button onClick={() => window.location.reload()} style={{
+                padding: '10px 24px', fontSize: '0.875rem', background: 'transparent',
+                border: '1px solid var(--border-subtle)', borderRadius: '8px',
+                color: 'var(--on-surface)', cursor: 'pointer',
+              }}>
+                Reload Page
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/NewRunModal.jsx
+++ b/frontend/src/components/NewRunModal.jsx
@@ -14,6 +14,9 @@ export default function NewRunModal({ onClose, onCreated }) {
   const [apps, setApps] = useState([]);
   const [appId, setAppId] = useState('');
   const [notes, setNotes] = useState('');
+  const [maxPages, setMaxPages] = useState(5);
+  const [instructions, setInstructions] = useState('');
+  const [focusAreas, setFocusAreas] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const navigate = useNavigate();
@@ -31,7 +34,12 @@ export default function NewRunModal({ onClose, onCreated }) {
     if (!appId) return setError('Please select an app');
     setLoading(true); setError('');
     try {
-      const res = await api.post('/runs', { app_id: appId, notes });
+      const test_config = {
+        max_pages: maxPages,
+        instructions: instructions.trim(),
+        focus_areas: focusAreas.trim(),
+      };
+      const res = await api.post('/runs', { app_id: appId, notes, test_config });
       onCreated?.();
       navigate(`/runs/${res.data.run.id}`);
     } catch (err) {
@@ -43,7 +51,7 @@ export default function NewRunModal({ onClose, onCreated }) {
 
   return (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(25,28,30,0.3)', backdropFilter: 'blur(4px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50, padding: '1rem' }}>
-      <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '14px', padding: '2rem', width: '100%', maxWidth: '480px', boxShadow: '0 8px 40px rgba(25,28,30,0.12)' }}>
+      <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '14px', padding: '2rem', width: '100%', maxWidth: '560px', maxHeight: '90vh', overflowY: 'auto', boxShadow: '0 8px 40px rgba(25,28,30,0.12)' }}>
         {/* Header */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.5rem' }}>
           <div>
@@ -77,11 +85,51 @@ export default function NewRunModal({ onClose, onCreated }) {
             )}
           </div>
 
+          {/* Test configuration */}
+          <div style={{ background: 'var(--surface-container-low)', borderRadius: '10px', padding: '1rem', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            <div style={{ fontSize: '0.7rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--on-surface-variant)', marginBottom: '2px' }}>Test Configuration</div>
+
+            {/* Instructions */}
+            <div>
+              <label style={{ display: 'block', marginBottom: '6px', fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--on-surface-variant)' }}>
+                What to test <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(optional)</span>
+              </label>
+              <textarea value={instructions} onChange={e => setInstructions(e.target.value)} rows={3}
+                placeholder="e.g. Test the client listing page, verify search and filters work, check pagination..."
+                className="ent-input" style={{ ...inputStyle, resize: 'vertical' }} />
+            </div>
+
+            {/* Focus areas */}
+            <div>
+              <label style={{ display: 'block', marginBottom: '6px', fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--on-surface-variant)' }}>
+                Focus areas <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(optional)</span>
+              </label>
+              <input type="text" value={focusAreas} onChange={e => setFocusAreas(e.target.value)}
+                placeholder="e.g. authentication, forms, navigation, data display"
+                className="ent-input" style={inputStyle} />
+            </div>
+
+            {/* Max pages */}
+            <div>
+              <label style={{ display: 'block', marginBottom: '6px', fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--on-surface-variant)' }}>
+                Pages to explore
+              </label>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                <input type="range" min={1} max={20} value={maxPages} onChange={e => setMaxPages(Number(e.target.value))}
+                  style={{ flex: 1, accentColor: 'var(--secondary)' }} />
+                <span style={{ minWidth: '32px', textAlign: 'center', fontWeight: 700, fontSize: '0.9rem', color: 'var(--secondary)' }}>{maxPages}</span>
+              </div>
+              <div style={{ fontSize: '0.75rem', color: 'var(--outline)', marginTop: '4px' }}>
+                More pages = deeper coverage but longer run time
+              </div>
+            </div>
+          </div>
+
           {/* Notes */}
           <div>
             <label style={{ display: 'block', marginBottom: '6px', fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--on-surface-variant)' }}>Notes <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(optional)</span></label>
-            <textarea value={notes} onChange={e => setNotes(e.target.value)} rows={3}
-              placeholder="e.g. Focus on checkout flow, test with slow network..."
+            <textarea value={notes} onChange={e => setNotes(e.target.value)} rows={2}
+              placeholder="e.g. Run after deployment, slow network conditions..."
               className="ent-input" style={{ ...inputStyle, resize: 'vertical' }} />
           </div>
 

--- a/frontend/src/components/NewRunModal.jsx
+++ b/frontend/src/components/NewRunModal.jsx
@@ -10,13 +10,15 @@ const inputStyle = {
   color: 'var(--on-surface)', boxSizing: 'border-box',
 };
 
-export default function NewRunModal({ onClose, onCreated }) {
+export default function NewRunModal({ onClose, onCreated, defaultAppId }) {
   const [apps, setApps] = useState([]);
   const [appId, setAppId] = useState('');
   const [notes, setNotes] = useState('');
   const [maxPages, setMaxPages] = useState(5);
   const [instructions, setInstructions] = useState('');
   const [focusAreas, setFocusAreas] = useState('');
+  const [screenshotLoginSteps, setScreenshotLoginSteps] = useState(true);
+  const [detailedReport, setDetailedReport] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const navigate = useNavigate();
@@ -25,9 +27,13 @@ export default function NewRunModal({ onClose, onCreated }) {
     api.get('/apps').then(res => {
       const list = res.data.apps || [];
       setApps(list);
-      if (list.length > 0) setAppId(list[0].id);
+      if (defaultAppId && list.some(a => a.id === defaultAppId)) {
+        setAppId(defaultAppId);
+      } else if (list.length > 0) {
+        setAppId(list[0].id);
+      }
     });
-  }, []);
+  }, [defaultAppId]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -38,6 +44,8 @@ export default function NewRunModal({ onClose, onCreated }) {
         max_pages: maxPages,
         instructions: instructions.trim(),
         focus_areas: focusAreas.trim(),
+        screenshot_login_steps: screenshotLoginSteps,
+        detailed_report: detailedReport,
       };
       const res = await api.post('/runs', { app_id: appId, notes, test_config });
       onCreated?.();
@@ -123,6 +131,54 @@ export default function NewRunModal({ onClose, onCreated }) {
                 More pages = deeper coverage but longer run time
               </div>
             </div>
+
+            {/* Login step screenshots toggle */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <div>
+                <label style={{ display: 'block', fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--on-surface-variant)' }}>
+                  Capture login step screenshots
+                </label>
+                <div style={{ fontSize: '0.72rem', color: 'var(--outline)', marginTop: '2px' }}>
+                  Screenshot after each auto-login action
+                </div>
+              </div>
+              <button type="button" onClick={() => setScreenshotLoginSteps(v => !v)} style={{
+                flexShrink: 0, width: '40px', height: '22px', borderRadius: '11px', border: 'none',
+                background: screenshotLoginSteps ? 'var(--secondary)' : 'var(--outline-variant)',
+                position: 'relative', cursor: 'pointer', transition: 'background 0.2s',
+              }}>
+                <span style={{
+                  position: 'absolute', top: '3px', width: '16px', height: '16px',
+                  borderRadius: '50%', background: '#fff', transition: 'left 0.2s',
+                  left: screenshotLoginSteps ? '21px' : '3px',
+                }} />
+              </button>
+            </div>
+
+            {/* Detailed report toggle */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingTop: '4px', borderTop: '1px solid rgba(197,198,207,0.2)' }}>
+              <div>
+                <label style={{ display: 'block', fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--on-surface-variant)' }}>
+                  Detailed AI report
+                </label>
+                <div style={{ fontSize: '0.72rem', color: 'var(--outline)', marginTop: '2px' }}>
+                  {detailedReport
+                    ? 'AI enriches each bug with steps, expected vs actual, severity'
+                    : 'Quick mode — raw bugs logged instantly, no AI enrichment'}
+                </div>
+              </div>
+              <button type="button" onClick={() => setDetailedReport(v => !v)} style={{
+                flexShrink: 0, width: '40px', height: '22px', borderRadius: '11px', border: 'none',
+                background: detailedReport ? 'var(--secondary)' : 'var(--outline-variant)',
+                position: 'relative', cursor: 'pointer', transition: 'background 0.2s',
+              }}>
+                <span style={{
+                  position: 'absolute', top: '3px', width: '16px', height: '16px',
+                  borderRadius: '50%', background: '#fff', transition: 'left 0.2s',
+                  left: detailedReport ? '21px' : '3px',
+                }} />
+              </button>
+            </div>
           </div>
 
           {/* Notes */}
@@ -138,7 +194,7 @@ export default function NewRunModal({ onClose, onCreated }) {
             <button type="button" onClick={onClose} style={{ flex: 1, padding: '12px', border: '1px solid var(--outline-variant)', borderRadius: '8px', background: 'transparent', color: 'var(--on-surface)', fontSize: '0.875rem', fontWeight: 500 }}>
               Cancel
             </button>
-            <button type="submit" disabled={loading || apps.length === 0} style={{ flex: 2, padding: '12px', background: 'linear-gradient(135deg, var(--primary), var(--primary-container))', color: '#fff', border: 'none', borderRadius: '8px', fontSize: '0.875rem', fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px', opacity: loading || apps.length === 0 ? 0.7 : 1 }}>
+            <button type="submit" disabled={loading || apps.length === 0} className="btn-primary" style={{ flex: 2, padding: '12px', fontSize: '0.875rem', fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px', opacity: loading || apps.length === 0 ? 0.7 : 1 }}>
               <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>play_arrow</span>
               {loading ? 'Starting...' : 'Start Test Run'}
             </button>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,88 +1,62 @@
 import React from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.jsx';
+import { useSidebar } from '../context/SidebarContext.jsx';
 
 const NAV_ITEMS = [
   { to: '/',        label: 'Dashboard',   icon: 'dashboard' },
   { to: '/apps',    label: 'Apps',        icon: 'apps' },
   { to: '/runs',    label: 'Test Runs',   icon: 'flaky' },
+  { to: '/bugs',    label: 'Bug Reports', icon: 'bug_report' },
+  { to: '/agents',  label: 'AI Agents',   icon: 'smart_toy' },
   { to: '/apitest', label: 'API Testing', icon: 'api' },
+  { to: '/profile', label: 'Profile',     icon: 'person' },
 ];
 
 export default function Sidebar() {
   const { user, logout } = useAuth();
+  const { collapsed } = useSidebar();
   const navigate = useNavigate();
 
   return (
-    <aside style={{
-      position: 'fixed', left: 0, top: 0, height: '100vh', width: '256px',
-      display: 'flex', flexDirection: 'column',
-      background: 'var(--surface-container-low)',
-      borderRight: '1px solid var(--outline-variant)',
-      zIndex: 50,
-    }}>
-      {/* Brand */}
-      <div style={{ padding: '2rem 1.5rem 1.5rem' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-          <div style={{
-            width: '32px', height: '32px', borderRadius: '6px',
-            background: 'var(--primary)',
-            display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-          }}>
-            <span className="material-symbols-outlined" style={{ color: '#fff', fontSize: '18px', fontVariationSettings: "'FILL' 1" }}>bug_report</span>
-          </div>
-          <div>
-            <div style={{ fontSize: '1rem', fontWeight: 700, color: 'var(--primary)', letterSpacing: '-0.02em' }}>BugHunter.AI</div>
-            <div style={{ fontSize: '10px', fontWeight: 600, color: 'var(--outline)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>Enterprise Audit</div>
-          </div>
-        </div>
-      </div>
-
-      {/* Nav */}
-      <nav style={{ flex: 1, marginTop: '8px' }}>
+    <aside className={`app-sidebar${collapsed ? ' app-sidebar--collapsed' : ''}`}>
+      <p className="app-sidebar__label">Navigation</p>
+      <nav className="app-sidebar__nav">
         {NAV_ITEMS.map(({ to, label, icon }) => (
           <NavLink
             key={to}
             to={to}
             end={to === '/'}
             className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
+            title={label}
           >
             <span className="material-symbols-outlined" style={{ fontSize: '20px' }}>{icon}</span>
-            <span style={{ letterSpacing: '0.01em' }}>{label}</span>
+            <span className="nav-link__text" style={{ letterSpacing: '0.01em' }}>{label}</span>
           </NavLink>
         ))}
       </nav>
 
-      {/* Footer */}
-      <div style={{ padding: '1.5rem', borderTop: '1px solid var(--outline-variant)' }}>
+      <div className="app-sidebar__footer">
         {user && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '1.25rem' }}>
-            <div style={{
-              width: '32px', height: '32px', borderRadius: '50%',
-              background: 'var(--primary)',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-              color: '#fff', fontSize: '0.75rem', fontWeight: 700, flexShrink: 0,
-            }}>
+          <div className="app-sidebar__user">
+            <div className="app-sidebar__user-avatar">
               {(user.name || user.email || 'U').charAt(0).toUpperCase()}
             </div>
-            <div style={{ overflow: 'hidden', flex: 1 }}>
-              <div style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--on-surface)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{user.name || 'User'}</div>
-              <div style={{ fontSize: '0.7rem', color: 'var(--outline)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{user.email}</div>
+            <div className="app-sidebar__user-meta">
+              <div className="app-sidebar__user-name">{user.name || 'User'}</div>
+              <div className="app-sidebar__user-email">{user.email}</div>
             </div>
           </div>
         )}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-          <a className="footer-link" style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '8px 4px', fontSize: '0.8rem', color: 'var(--on-surface-variant)', borderRadius: '6px', cursor: 'pointer' }}>
-            <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>menu_book</span>
-            Documentation
-          </a>
+        <div className="app-sidebar__actions">
           <button
+            type="button"
             onClick={() => { logout(); navigate('/login'); }}
-            className="footer-link-danger"
-            style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '8px 4px', fontSize: '0.8rem', color: 'var(--on-surface-variant)', background: 'none', border: 'none', borderRadius: '6px', textAlign: 'left' }}
+            className="footer-link-danger app-sidebar__action"
+            title="Log out"
           >
             <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>logout</span>
-            Log out
+            <span className="app-sidebar__action-text">Log out</span>
           </button>
         </div>
       </div>

--- a/frontend/src/components/TestRuns.jsx
+++ b/frontend/src/components/TestRuns.jsx
@@ -1,31 +1,42 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
 import api from '../services/api.js';
 import NewRunModal from './NewRunModal.jsx';
 
 const STATUS_CONFIG = {
-  pending:   { bg: '#fef3c7', color: '#92400e',           rail: '#f59e0b', icon: 'hourglass_empty' },
-  running:   { bg: 'rgba(0,88,190,0.08)', color: 'var(--secondary)', rail: 'var(--secondary)', icon: 'play_arrow' },
-  completed: { bg: '#f0fdf4', color: '#16a34a',           rail: '#22c55e', icon: 'check' },
-  failed:    { bg: 'var(--error-container)', color: 'var(--error)', rail: 'var(--error)', icon: 'error_outline' },
+  pending:   { bg: '#fef3c7',               color: '#92400e',          rail: '#f59e0b',          icon: 'hourglass_empty' },
+  running:   { bg: 'var(--secondary-soft)', color: 'var(--secondary)', rail: 'var(--secondary)', icon: 'play_arrow' },
+  completed: { bg: '#f0fdf4',               color: '#16a34a',          rail: '#22c55e',          icon: 'check' },
+  failed:    { bg: 'var(--error-container)', color: 'var(--error)',     rail: 'var(--error)',     icon: 'error_outline' },
+  paused:    { bg: '#ede9fe',               color: '#5b21b6',          rail: '#7c3aed',          icon: 'pause_circle' },
+  cancelled: { bg: '#fef3c7',               color: '#92400e',          rail: '#d97706',          icon: 'stop_circle' },
 };
 
-const ACTIVE_STATUSES = new Set(['pending', 'running']);
+const ACTIVE_STATUSES = new Set(['pending', 'running', 'paused']);
 
 export default function TestRuns() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const appIdFilter = searchParams.get('app_id') || '';
+
   const [runs, setRuns] = useState([]);
+  const [apps, setApps] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const pollRef = useRef(null);
 
+  useEffect(() => {
+    api.get('/apps').then((res) => setApps(res.data.apps || [])).catch(() => setApps([]));
+  }, []);
+
   const fetchRuns = useCallback(() => {
-    api.get('/runs')
+    const q = appIdFilter ? `?app_id=${encodeURIComponent(appIdFilter)}` : '';
+    api.get(`/runs${q}`)
       .then(res => { setRuns(res.data.runs || []); setError(null); })
       .catch(err => setError(err.response?.data?.error || err.message || 'Failed to load runs'))
       .finally(() => setLoading(false));
-  }, []);
+  }, [appIdFilter]);
 
   useEffect(() => { fetchRuns(); }, [fetchRuns]);
 
@@ -42,29 +53,57 @@ export default function TestRuns() {
     catch (err) { setError(err.response?.data?.error || err.message || 'Failed to delete run'); }
   };
 
+  const handleStop = async (id) => {
+    try { await api.post(`/runs/${id}/stop`); fetchRuns(); }
+    catch (err) { setError(err.response?.data?.error || err.message || 'Failed to stop run'); }
+  };
+
   const completed = runs.filter(r => r.status === 'completed').length;
   const successRate = runs.length > 0 ? Math.round((completed / runs.length) * 100) : 0;
-
   return (
     <div>
       {/* Page header */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '2.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
-          <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-tertiary-container)', textTransform: 'uppercase', letterSpacing: '0.2em', marginBottom: '6px' }}>Audit History</span>
-          <h2 style={{ fontSize: '2.25rem', fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--primary)' }}>Test Runs</h2>
+          <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.14em', marginBottom: '6px' }}>Audit history</span>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--primary)' }}>Test runs</h1>
         </div>
-        <button onClick={() => setShowModal(true)} style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '12px 20px', background: 'var(--primary)', color: '#fff', border: 'none', borderRadius: '8px', fontWeight: 500, fontSize: '0.875rem' }}>
-          <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>play_arrow</span>
-          Start New Run
-        </button>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', alignItems: 'center' }}>
+          <label style={{ fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--on-surface-variant)', display: 'flex', alignItems: 'center', gap: '8px' }}>
+            App
+            <select
+              value={appIdFilter}
+              onChange={(e) => {
+                const v = e.target.value;
+                const next = new URLSearchParams(searchParams);
+                if (v) next.set('app_id', v);
+                else next.delete('app_id');
+                setSearchParams(next);
+              }}
+              className="ent-input"
+              style={{ minWidth: '200px', padding: '8px 12px', borderRadius: '8px', fontSize: '0.875rem', border: '1px solid var(--border-subtle)', background: 'var(--surface-container-lowest)', color: 'var(--on-surface)' }}
+            >
+              <option value="">All apps</option>
+              {apps.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name || a.url || a.id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" onClick={() => setShowModal(true)} className="btn-primary">
+            <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>play_arrow</span>
+            Start new run
+          </button>
+        </div>
       </div>
 
       {/* Stats banner */}
       {runs.length > 0 && (
         <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '1.25rem', marginBottom: '2rem' }}>
-          <div style={{ background: 'var(--surface-container-low)', borderRadius: '12px', padding: '1.5rem 2rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', overflow: 'hidden', position: 'relative' }}>
+          <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', padding: '1.5rem 2rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', overflow: 'hidden', position: 'relative', border: '1px solid var(--border-subtle)' }}>
             <div>
-              <p style={{ fontSize: '11px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--on-surface-variant)', marginBottom: '8px' }}>Success Rate</p>
+              <p style={{ fontSize: '11px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--on-surface-variant)', marginBottom: '8px' }}>Success rate</p>
               <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px' }}>
                 <span style={{ fontSize: '2.75rem', fontWeight: 300, letterSpacing: '-0.03em', color: 'var(--primary)' }}>{successRate}%</span>
                 <span style={{ fontSize: '0.875rem', fontWeight: 600, color: 'var(--secondary)' }}>{completed} of {runs.length} runs</span>
@@ -72,15 +111,15 @@ export default function TestRuns() {
             </div>
             <div style={{ display: 'flex', alignItems: 'flex-end', gap: '4px', height: '64px' }}>
               {[0.5, 0.65, 0.5, 0.8, 1].map((h, i) => (
-                <div key={i} style={{ width: '16px', background: `rgba(0,88,190,${0.15 + h * 0.25})`, height: `${h * 100}%`, borderRadius: '3px 3px 0 0' }} />
+                <div key={i} style={{ width: '16px', background: `rgba(13, 115, 119, ${0.15 + h * 0.25})`, height: `${h * 100}%`, borderRadius: '3px 3px 0 0' }} />
               ))}
             </div>
-            <div style={{ position: 'absolute', right: '-48px', top: '-48px', width: '200px', height: '200px', background: 'rgba(0,88,190,0.04)', borderRadius: '50%', filter: 'blur(40px)' }} />
+            <div style={{ position: 'absolute', right: '-48px', top: '-48px', width: '200px', height: '200px', background: 'rgba(13, 115, 119, 0.06)', borderRadius: '50%', filter: 'blur(40px)' }} />
           </div>
-          <div style={{ background: 'var(--primary)', color: '#fff', borderRadius: '12px', padding: '1.5rem 2rem', minWidth: '220px' }}>
+          <div style={{ background: 'var(--primary-button)', color: '#fff', borderRadius: '8px', padding: '1.5rem 2rem', minWidth: '220px' }}>
             <p style={{ fontSize: '11px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', opacity: 0.6, marginBottom: '8px' }}>Total Bugs Found</p>
             <span style={{ fontSize: '2.75rem', fontWeight: 300, letterSpacing: '-0.03em', display: 'block' }}>
-              {runs.reduce((sum, r) => sum + (r.bug_count || 0), 0)}
+              {runs.reduce((sum, r) => sum + Number(r.bug_count ?? 0), 0)}
             </span>
             <p style={{ fontSize: '0.75rem', opacity: 0.7, marginTop: '4px' }}>Across {runs.length} test runs</p>
           </div>
@@ -96,12 +135,12 @@ export default function TestRuns() {
 
       {loading ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--on-surface-variant)', padding: '2rem 0' }}>
-          <span className="material-symbols-outlined pulse" style={{ color: 'var(--secondary)' }}>autorenew</span> Loading...
+          <span className="material-symbols-outlined pulse" style={{ color: 'var(--link)' }}>autorenew</span> Loading...
         </div>
       ) : (
-        <div style={{ background: 'var(--surface-container-low)', borderRadius: '16px', padding: '8px' }}>
+        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', padding: '0', border: '1px solid var(--border-subtle)', overflow: 'hidden' }}>
           {/* Column headers */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 130px 160px 100px 90px 80px', padding: '10px 20px', fontSize: '10px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.12em' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 130px 160px 100px 90px 80px', padding: '12px 20px', fontSize: '10px', fontWeight: 700, color: 'var(--on-surface)', textTransform: 'uppercase', letterSpacing: '0.12em', background: 'var(--table-header-bg)', borderBottom: '1px solid var(--border-subtle)' }}>
             <span>Run / App</span>
             <span style={{ textAlign: 'center' }}>Status</span>
             <span>Start Time</span>
@@ -116,24 +155,28 @@ export default function TestRuns() {
               No test runs yet. Start your first run.
             </div>
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-              {runs.map(run => {
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0' }}>
+              {runs.map((run, idx) => {
                 const cfg = STATUS_CONFIG[run.status] || STATUS_CONFIG.pending;
                 const duration = run.started_at && run.completed_at
                   ? (() => { const s = Math.round((new Date(run.completed_at) - new Date(run.started_at)) / 1000); return s < 60 ? `${s}s` : `${Math.floor(s/60)}m ${s%60}s`; })()
                   : '—';
+                const isRowActive = ACTIVE_STATUSES.has(run.status);
                 return (
-                  <div key={run.id} className="hoverable-card" style={{ display: 'grid', gridTemplateColumns: '1fr 130px 160px 100px 90px 80px', alignItems: 'center', padding: '16px 20px', background: 'var(--surface-container-lowest)', borderRadius: '10px' }}>
+                  <div key={run.id} className={`hoverable-card${isRowActive ? ' active-run' : ''}`} style={{ display: 'grid', gridTemplateColumns: '1fr 130px 160px 100px 90px 80px', alignItems: 'center', padding: '16px 20px', background: isRowActive ? undefined : 'var(--surface-container-lowest)', borderBottom: idx < runs.length - 1 ? '1px solid var(--border-subtle)' : 'none' }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                      <div style={{ width: '4px', height: '32px', background: cfg.rail, borderRadius: '2px', flexShrink: 0 }} />
+                      <div
+                        className={isRowActive ? 'scan-bar' : ''}
+                        style={{ width: '4px', height: '32px', background: cfg.rail, borderRadius: '2px', flexShrink: 0 }}
+                      />
                       <div>
-                        <Link to={`/runs/${run.id}`} style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--primary)' }}>#{run.id?.toString().slice(-4) || '—'}</Link>
+                        <Link to={`/runs/${run.id}`} style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--link)' }}>#{run.id?.toString().slice(-4) || '—'}</Link>
                         <div style={{ fontSize: '0.875rem', color: 'var(--on-surface-variant)', marginTop: '2px' }}>{run.app_name || '—'}</div>
                       </div>
                     </div>
                     <div style={{ display: 'flex', justifyContent: 'center' }}>
                       <span style={{ padding: '3px 10px', borderRadius: '999px', fontSize: '10px', fontWeight: 700, background: cfg.bg, color: cfg.color, display: 'flex', alignItems: 'center', gap: '4px' }}>
-                        {run.status === 'running' && <span className="pulse" style={{ width: '5px', height: '5px', borderRadius: '50%', background: 'var(--secondary)', display: 'inline-block' }} />}
+                        {isRowActive && <span className="pulse" style={{ width: '5px', height: '5px', borderRadius: '50%', background: cfg.rail, display: 'inline-block', flexShrink: 0 }} />}
                         <span className="material-symbols-outlined" style={{ fontSize: '11px', fontVariationSettings: "'wght' 700" }}>{cfg.icon}</span>
                         {run.status?.toUpperCase()}
                       </span>
@@ -142,11 +185,20 @@ export default function TestRuns() {
                       {run.started_at ? formatDistanceToNow(new Date(run.started_at), { addSuffix: true }) : '—'}
                     </span>
                     <span style={{ fontSize: '0.8rem', color: 'var(--on-surface-variant)' }}>{duration}</span>
-                    <span style={{ fontSize: '1.25rem', fontWeight: 300, color: 'var(--primary)', textAlign: 'right' }}>{run.bug_count || 0}</span>
-                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                      <button onClick={() => handleDelete(run.id)} style={{ padding: '6px', background: 'none', border: 'none', color: 'var(--outline)' }} title="Delete">
-                        <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>delete</span>
-                      </button>
+                    <span style={{ fontSize: '1.25rem', fontWeight: 300, color: 'var(--primary)', textAlign: 'right' }}>{Number(run.bug_count ?? 0)}</span>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '4px' }}>
+                      {isRowActive ? (
+                        <button onClick={() => handleStop(run.id)}
+                          style={{ padding: '5px 10px', borderRadius: '6px', fontSize: '11px', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '3px', background: 'var(--error-container)', color: 'var(--error)', border: '1px solid var(--error)', cursor: 'pointer' }}
+                          title="Stop this run">
+                          <span className="material-symbols-outlined" style={{ fontSize: '13px' }}>stop</span>
+                          Stop
+                        </button>
+                      ) : (
+                        <button onClick={() => handleDelete(run.id)} style={{ padding: '6px', background: 'none', border: 'none', color: 'var(--outline)' }} title="Delete">
+                          <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>delete</span>
+                        </button>
+                      )}
                     </div>
                   </div>
                 );

--- a/frontend/src/components/UserProfile.jsx
+++ b/frontend/src/components/UserProfile.jsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const inputStyle = {
+  width: '100%',
+  padding: '10px 12px',
+  background: 'var(--surface-container-lowest)',
+  border: '1px solid var(--border-subtle)',
+  borderRadius: '6px',
+  fontSize: '0.875rem',
+  color: 'var(--on-surface)',
+  boxSizing: 'border-box',
+};
+
+const labelStyle = {
+  display: 'block',
+  marginBottom: '6px',
+  fontSize: '0.7rem',
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  color: 'var(--on-surface-variant)',
+};
+
+export default function UserProfile() {
+  const { user, updateProfile } = useAuth();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [initialEmail, setInitialEmail] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (user) {
+      setName(user.name || '');
+      setEmail(user.email || '');
+      setInitialEmail(user.email || '');
+    }
+  }, [user]);
+
+  const emailChanged = email.trim().toLowerCase() !== initialEmail.trim().toLowerCase();
+  const wantsPasswordChange = newPassword.length > 0 || confirmPassword.length > 0;
+  const needsCurrentPassword = emailChanged || wantsPasswordChange;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+
+    if (wantsPasswordChange) {
+      if (newPassword.length < 8) {
+        setError('New password must be at least 8 characters');
+        return;
+      }
+      if (newPassword !== confirmPassword) {
+        setError('New passwords do not match');
+        return;
+      }
+    }
+
+    if (needsCurrentPassword && !currentPassword) {
+      setError('Enter your current password to change email or password');
+      return;
+    }
+
+    const payload = {};
+    if (name.trim() !== (user?.name || '')) payload.name = name.trim();
+    if (emailChanged) payload.email = email.trim();
+    if (needsCurrentPassword) payload.current_password = currentPassword;
+    if (wantsPasswordChange) payload.new_password = newPassword;
+
+    if (Object.keys(payload).length === 0) {
+      setMessage('Nothing to save');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await updateProfile(payload);
+      setInitialEmail(email.trim());
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setMessage('Profile updated');
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Update failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <Link to="/" style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--link)', display: 'inline-flex', alignItems: 'center', gap: '4px', marginBottom: '12px' }}>
+          <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>arrow_back</span>
+          Back to dashboard
+        </Link>
+        <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, color: 'var(--on-surface-variant)', textTransform: 'uppercase', letterSpacing: '0.14em', marginBottom: '6px' }}>Account</span>
+        <h1 style={{ fontSize: '1.75rem', fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--primary)' }}>Profile</h1>
+        <p style={{ color: 'var(--on-surface-variant)', fontSize: '0.875rem', marginTop: '6px', maxWidth: '520px' }}>
+          Update your name, email, or password. Changing email or password requires your current password.
+        </p>
+      </div>
+
+      {message && (
+        <div style={{ background: '#f0fdf4', color: '#166534', padding: '10px 14px', borderRadius: '6px', marginBottom: '1rem', fontSize: '0.875rem', border: '1px solid #bbf7d0' }}>
+          {message}
+        </div>
+      )}
+      {error && (
+        <div style={{ background: 'var(--error-container)', color: 'var(--error)', padding: '10px 14px', borderRadius: '6px', marginBottom: '1rem', fontSize: '0.875rem' }}>
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} style={{ maxWidth: '560px' }}>
+        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', padding: '1.5rem', border: '1px solid var(--border-subtle)', marginBottom: '1.25rem' }}>
+          <h2 style={{ fontSize: '0.875rem', fontWeight: 700, color: 'var(--primary)', marginBottom: '1rem' }}>Profile details</h2>
+          <div style={{ marginBottom: '1rem' }}>
+            <label style={labelStyle}>Full name</label>
+            <input type="text" value={name} onChange={(e) => setName(e.target.value)} className="ent-input" style={inputStyle} autoComplete="name" />
+          </div>
+          <div>
+            <label style={labelStyle}>Email</label>
+            <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="ent-input" style={inputStyle} autoComplete="email" />
+          </div>
+        </div>
+
+        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', padding: '1.5rem', border: '1px solid var(--border-subtle)', marginBottom: '1.25rem' }}>
+          <h2 style={{ fontSize: '0.875rem', fontWeight: 700, color: 'var(--primary)', marginBottom: '0.5rem' }}>Change password</h2>
+          <p style={{ fontSize: '0.8rem', color: 'var(--outline)', marginBottom: '1rem' }}>Leave blank to keep your current password.</p>
+          <div style={{ marginBottom: '1rem' }}>
+            <label style={labelStyle}>New password</label>
+            <input type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className="ent-input" style={inputStyle} autoComplete="new-password" placeholder="Min. 8 characters" />
+          </div>
+          <div>
+            <label style={labelStyle}>Confirm new password</label>
+            <input type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className="ent-input" style={inputStyle} autoComplete="new-password" />
+          </div>
+        </div>
+
+        <div style={{ background: 'var(--surface-container-lowest)', borderRadius: '8px', padding: '1.5rem', border: '1px solid var(--border-subtle)', marginBottom: '1.25rem' }}>
+          <h2 style={{ fontSize: '0.875rem', fontWeight: 700, color: 'var(--primary)', marginBottom: '0.5rem' }}>Verify</h2>
+          <p style={{ fontSize: '0.8rem', color: 'var(--outline)', marginBottom: '1rem' }}>
+            {needsCurrentPassword
+              ? 'Enter your current password to apply these changes.'
+              : 'Required only when you change email or password.'}
+          </p>
+          <div>
+            <label style={labelStyle}>Current password</label>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              className="ent-input"
+              style={inputStyle}
+              autoComplete="current-password"
+              placeholder={needsCurrentPassword ? 'Required' : 'If changing email or password'}
+            />
+          </div>
+        </div>
+
+        <button type="submit" disabled={saving} className="btn-primary" style={{ padding: '12px 24px', opacity: saving ? 0.7 : 1 }}>
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -48,8 +48,14 @@ export function AuthProvider({ children }) {
     setUser(null);
   }, []);
 
+  const updateProfile = useCallback(async (payload) => {
+    const res = await api.patch('/auth/profile', payload);
+    setUser(res.data.user);
+    return res.data.user;
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, register, logout, updateProfile }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/context/NotificationContext.jsx
+++ b/frontend/src/context/NotificationContext.jsx
@@ -1,0 +1,94 @@
+import React, { createContext, useCallback, useContext, useState } from 'react';
+
+const NotificationContext = createContext(null);
+
+let nextId = 0;
+
+const ICONS = {
+  success: 'check_circle',
+  error: 'error',
+  warning: 'warning',
+  info: 'info',
+};
+
+const COLORS = {
+  success: 'var(--success, #4caf50)',
+  error: 'var(--error, #ef4444)',
+  warning: 'var(--warning, #f59e0b)',
+  info: 'var(--link, #6c8eff)',
+};
+
+export function NotificationProvider({ children }) {
+  const [notifications, setNotifications] = useState([]);
+
+  const removeNotification = useCallback((id) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  const addNotification = useCallback((message, type = 'info', duration = 4000) => {
+    const id = ++nextId;
+    setNotifications((prev) => [...prev, { id, message, type }]);
+    if (duration > 0) {
+      setTimeout(() => removeNotification(id), duration);
+    }
+    return id;
+  }, [removeNotification]);
+
+  const notify = {
+    success: (msg, dur) => addNotification(msg, 'success', dur),
+    error: (msg, dur) => addNotification(msg, 'error', dur ?? 6000),
+    warning: (msg, dur) => addNotification(msg, 'warning', dur),
+    info: (msg, dur) => addNotification(msg, 'info', dur),
+  };
+
+  return (
+    <NotificationContext.Provider value={notify}>
+      {children}
+      {/* Toast container */}
+      <div style={{
+        position: 'fixed', top: '1rem', right: '1rem', zIndex: 10000,
+        display: 'flex', flexDirection: 'column', gap: '0.5rem',
+        pointerEvents: 'none', maxWidth: '400px',
+      }}>
+        {notifications.map((n) => (
+          <div key={n.id} style={{
+            display: 'flex', alignItems: 'center', gap: '10px',
+            padding: '12px 16px', borderRadius: '8px',
+            background: 'var(--surface-container, #1e1e2e)',
+            border: `1px solid ${COLORS[n.type]}33`,
+            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+            color: 'var(--on-surface, #e0e0e0)',
+            fontSize: '0.875rem', pointerEvents: 'auto',
+            animation: 'slideIn 0.2s ease-out',
+          }}>
+            <span className="material-symbols-outlined" style={{
+              color: COLORS[n.type], fontSize: '20px', flexShrink: 0,
+              fontVariationSettings: "'FILL' 1",
+            }}>
+              {ICONS[n.type]}
+            </span>
+            <span style={{ flex: 1 }}>{n.message}</span>
+            <button onClick={() => removeNotification(n.id)} style={{
+              background: 'none', border: 'none', color: 'var(--outline, #999)',
+              cursor: 'pointer', padding: '2px', lineHeight: 1, flexShrink: 0,
+            }}>
+              <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>close</span>
+            </button>
+          </div>
+        ))}
+      </div>
+      <style>{`
+        @keyframes slideIn {
+          from { transform: translateX(100%); opacity: 0; }
+          to { transform: translateX(0); opacity: 1; }
+        }
+      `}</style>
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotification() {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) throw new Error('useNotification must be used within NotificationProvider');
+  return ctx;
+}

--- a/frontend/src/context/SidebarContext.jsx
+++ b/frontend/src/context/SidebarContext.jsx
@@ -1,0 +1,41 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+const SidebarContext = createContext(null);
+
+const STORAGE_KEY = 'bughunter_sidebar_collapsed';
+
+export function SidebarProvider({ children }) {
+  const [collapsed, setCollapsedState] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, collapsed ? '1' : '0');
+    } catch { /* ignore */ }
+  }, [collapsed]);
+
+  const setCollapsed = useCallback((value) => {
+    setCollapsedState(value);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsedState((v) => !v);
+  }, []);
+
+  return (
+    <SidebarContext.Provider value={{ collapsed, setCollapsed, toggle }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export function useSidebar() {
+  const ctx = useContext(SidebarContext);
+  if (!ctx) throw new Error('useSidebar must be used within SidebarProvider');
+  return ctx;
+}

--- a/frontend/src/data/agentProfiles.js
+++ b/frontend/src/data/agentProfiles.js
@@ -1,0 +1,101 @@
+/**
+ * Static metadata for BugHunter.AI LangGraph agents (order matches pipeline).
+ * @see agent/graph/graph.py
+ */
+
+export const PIPELINE_AGENT_IDS = [
+  'orchestrator',
+  'explorer',
+  'validator',
+  'security',
+  'reporter',
+];
+
+/** @typedef {{ id: string; name: string; icon: string; role: string; description: string; capabilities: string[]; tools: string[]; pipelinePosition: number; color: string }} AgentProfile */
+
+/** @type {AgentProfile[]} */
+export const AGENT_PROFILES = [
+  {
+    id: 'orchestrator',
+    name: 'Orchestrator',
+    icon: 'psychology',
+    role: 'Test Strategist',
+    description:
+      'Analyzes the target URL, credentials, and app memory to produce a JSON testing strategy. Parsed pages and focus areas are merged with memory-driven priorities so the Explorer visits the right URLs first and uses the plan in its prompts.',
+    capabilities: [
+      'Test planning',
+      'Auth-aware strategy',
+      'Memory-informed prioritization',
+      'User instructions & focus areas',
+    ],
+    tools: ['LLM', 'App memory context', 'Progress events'],
+    pipelinePosition: 1,
+    color: '#6366f1',
+  },
+  {
+    id: 'explorer',
+    name: 'Explorer',
+    icon: 'travel_explore',
+    role: 'Browser Explorer',
+    description:
+      'Drives Playwright to navigate the app, handle logins (flows, memory replay, or smart LLM login), capture screenshots, and record console/network issues. Visits priority pages and discovers links to broaden coverage.',
+    capabilities: [
+      'Multi-page exploration',
+      'Login flows & screenshots',
+      'Console & network error capture',
+      'App memory–driven page priority',
+    ],
+    tools: ['Playwright (BrowserTool)', 'LLM (navigation hints)', 'Screenshots'],
+    pipelinePosition: 2,
+    color: '#0ea5e9',
+  },
+  {
+    id: 'validator',
+    name: 'Validator',
+    icon: 'fact_check',
+    role: 'Functional QA Analyst',
+    description:
+      'Reviews explorer observations (observe / errors_detected steps) with an LLM to find functional, UI, and error bugs—404s, layout issues, failed requests, validation problems, and accessibility gaps.',
+    capabilities: [
+      'Screenshot & step analysis',
+      'Bug triage by severity',
+      'Live bug_found notifications',
+    ],
+    tools: ['LLM', 'Test step JSON'],
+    pipelinePosition: 3,
+    color: '#a855f7',
+  },
+  {
+    id: 'security',
+    name: 'Security',
+    icon: 'security',
+    role: 'Security Tester',
+    description:
+      'Runs active checks on the seed URL and pages the Explorer visited (capped): reflected XSS and SQLi probes on form inputs, plus regex scans for exposed secrets. One browser session per URL.',
+    capabilities: ['XSS probes', 'SQLi probes', 'Secret pattern scan'],
+    tools: ['Playwright (BrowserTool)', 'Payload & regex libraries'],
+    pipelinePosition: 4,
+    color: '#dc2626',
+  },
+  {
+    id: 'reporter',
+    name: 'Reporter',
+    icon: 'article',
+    role: 'Bug Report Author',
+    description:
+      'Turns raw findings into structured, developer-ready reports (title, steps, severity, type). Marks regressions when a bug fingerprint matches known issues in app memory.',
+    capabilities: [
+      'Structured bug reports',
+      'Regression detection',
+      'Severity & type normalization',
+    ],
+    tools: ['LLM', 'Fingerprinting (app memory)'],
+    pipelinePosition: 5,
+    color: '#16a34a',
+  },
+];
+
+/** @param {string} id */
+export function getAgentProfile(id) {
+  return AGENT_PROFILES.find((a) => a.id === id) || null;
+}

--- a/frontend/src/data/liveEventConfig.js
+++ b/frontend/src/data/liveEventConfig.js
@@ -1,0 +1,14 @@
+/** Styling for SSE live event types (shared by BugReports, AgentActivityLog). */
+export const EVENT_CONFIG = {
+  agent_start: { color: 'var(--secondary)', icon: 'play_circle' },
+  agent_done: { color: '#16a34a', icon: 'check_circle' },
+  page_visited: { color: 'var(--outline)', icon: 'travel_explore' },
+  login_step: { color: '#f59e0b', icon: 'key' },
+  bug_found: { color: 'var(--error)', icon: 'bug_report' },
+  run_complete:  { color: '#16a34a', icon: 'verified' },
+  run_failed:    { color: 'var(--error)', icon: 'error' },
+  run_stopped:   { color: '#d97706', icon: 'stop_circle' },
+  run_cancelled: { color: '#d97706', icon: 'stop_circle' },
+  run_paused:    { color: '#7c3aed', icon: 'pause_circle' },
+  run_resumed:   { color: 'var(--secondary)', icon: 'play_circle' },
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,22 +1,43 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* Korn Ferry Talent Suite–inspired enterprise tokens */
 :root {
-  --primary: #031635;
-  --primary-container: #1a2b4b;
-  --secondary: #0058be;
-  --surface: #f7f9fb;
-  --surface-container-low: #f2f4f6;
+  --header-height: 56px;
+  --sidebar-width: 260px;
+
+  --primary: #0d3d3d;
+  --primary-strong: #082828;
+  --primary-container: #164f4f;
+  --primary-button: #1b4332;
+  --primary-button-hover: #2d6a4f;
+
+  --secondary: #0d7377;
+  --secondary-soft: rgba(13, 115, 119, 0.1);
+  --link: #0d7377;
+  --link-hover: #0a5c5f;
+
+  --surface: #f5f5f5;
+  --surface-container-low: #fafafa;
   --surface-container-lowest: #ffffff;
-  --surface-container: #eceef0;
-  --surface-container-high: #e6e8ea;
-  --surface-container-highest: #e0e3e5;
-  --on-surface: #191c1e;
-  --on-surface-variant: #44474e;
-  --outline: #75777f;
-  --outline-variant: #c5c6cf;
-  --error: #ba1a1a;
-  --error-container: #ffdad6;
-  --on-tertiary-container: #b08d5b;
+  --surface-container: #f0f0f0;
+  --surface-container-high: #ebebeb;
+  --surface-container-highest: #e0e0e0;
+  --table-header-bg: #f5f5f5;
+  --border-subtle: #e0e0e0;
+
+  --on-surface: #1a1a1a;
+  --on-surface-variant: #4b4b4b;
+  --outline: #6b7280;
+  --outline-variant: #d1d5db;
+  --on-tertiary-container: #6b7280;
+
+  --info-banner-bg: #e8f4fc;
+  --info-banner-border: #b8d9f0;
+  --warning-banner-bg: #fff4e6;
+  --warning-banner-border: #e8c48a;
+
+  --error: #b91c1c;
+  --error-container: #fee2e2;
 }
 
 body {
@@ -26,8 +47,186 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-a { color: inherit; text-decoration: none; }
+a { color: var(--link); text-decoration: none; }
+a:hover { color: var(--link-hover); }
+
 button { cursor: pointer; font-family: inherit; }
+
+/* Top app bar */
+.app-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-height);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem 0 0.75rem;
+  background: var(--surface-container-lowest);
+  border-bottom: 1px solid var(--border-subtle);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.03);
+}
+
+.app-header__left {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.app-header__icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: none;
+  background: transparent;
+  color: var(--on-surface);
+  border-radius: 8px;
+  transition: background 0.15s;
+}
+.app-header__icon-btn:hover {
+  background: var(--surface-container-high);
+}
+
+.app-header__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-left: 4px;
+}
+
+.app-header__brand-title {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--primary);
+  line-height: 1.2;
+}
+
+.app-header__brand-sub {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--on-surface-variant);
+  opacity: 0.85;
+}
+
+.app-header__right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.app-header__user {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 8px;
+  padding: 4px 6px 4px 4px;
+  border-radius: 999px;
+  cursor: pointer;
+  color: inherit;
+}
+a.app-header__user {
+  text-decoration: none;
+}
+.app-header__user:hover {
+  background: var(--surface-container-high);
+}
+
+.app-header__avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #1e6bb8;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.app-header__chevron {
+  color: var(--outline);
+}
+
+/* Global footer */
+.app-footer {
+  margin-top: auto;
+  padding: 1rem 0 0;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--outline);
+}
+
+.app-footer__links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.app-footer__links a {
+  color: var(--outline);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.app-footer__links a:hover {
+  color: var(--primary);
+}
+
+/* Primary CTA — forest green */
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 20px;
+  background: var(--primary-button);
+  color: #fff !important;
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: background 0.15s;
+}
+.btn-primary:hover:not(:disabled) {
+  background: var(--primary-button-hover);
+}
+.btn-primary:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+/* Info / notice banners */
+.info-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 1.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--info-banner-border);
+  background: var(--info-banner-bg);
+  font-size: 0.875rem;
+  color: var(--on-surface-variant);
+  line-height: 1.45;
+}
+.info-banner__icon {
+  flex-shrink: 0;
+  color: var(--secondary);
+  margin-top: 2px;
+}
 
 .material-symbols-outlined {
   font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
@@ -35,50 +234,332 @@ button { cursor: pointer; font-family: inherit; }
   line-height: 1;
 }
 
-/* Sidebar nav links */
+/* Sidebar nav */
 .nav-link {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 24px;
+  padding: 11px 20px;
+  margin: 0 8px;
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--on-surface-variant);
-  border-left: 4px solid transparent;
+  border-left: 3px solid transparent;
+  border-radius: 0 6px 6px 0;
   transition: background 0.15s, color 0.15s;
   text-decoration: none;
 }
-.nav-link:hover { background: var(--surface-container-high); color: var(--primary); }
-.nav-link.active { color: var(--secondary); border-left-color: var(--secondary); background: rgba(255,255,255,0.6); }
+.nav-link:hover {
+  background: var(--surface-container-high);
+  color: var(--primary);
+}
+.nav-link.active {
+  color: var(--secondary);
+  border-left-color: var(--secondary);
+  background: var(--secondary-soft);
+  font-weight: 600;
+}
 
-/* Glass card */
 .glass-card {
-  background: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
 }
 
-/* Hover row */
 .hoverable-row { transition: background 0.15s; }
-.hoverable-row:hover { background: rgba(247,249,251,0.8); }
-.hoverable-card { transition: transform 0.2s; }
-.hoverable-card:hover { transform: scale(1.003); }
+.hoverable-row:hover { background: var(--surface-container-low); }
+.hoverable-card { transition: transform 0.2s, box-shadow 0.2s; }
+.hoverable-card:hover { transform: translateY(-1px); box-shadow: 0 2px 8px rgba(13, 61, 61, 0.06); }
 
-/* Pulse animation */
 @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
 .pulse { animation: pulse 2s ease-in-out infinite; }
 
-/* Scrollbar */
+@keyframes scan-bar {
+  0%,100% { opacity: 1; height: 32px; }
+  50%      { opacity: 0.5; height: 24px; }
+}
+.scan-bar { animation: scan-bar 1.4s ease-in-out infinite; align-self: center; }
+
+@keyframes active-row-bg {
+  0%,100% { background-color: var(--surface-container-lowest); }
+  50%      { background-color: var(--secondary-soft); }
+}
+.active-run { background: var(--surface-container-lowest); animation: active-row-bg 2.5s ease-in-out infinite; }
+
+/* ── Agent pipeline tracker (BugReports + AgentProfiles) ─────────────────── */
+@keyframes agent-pipeline-step-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes agent-pipeline-ring {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(13, 115, 119, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(13, 115, 119, 0);
+  }
+}
+
+@keyframes agent-pipeline-connector-flow {
+  0%, 100% {
+    opacity: 0.45;
+    transform: translateX(0);
+  }
+  50% {
+    opacity: 1;
+    transform: translateX(3px);
+  }
+}
+
+@keyframes agent-pipeline-check-pop {
+  0% {
+    transform: scale(0.85);
+  }
+  60% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.agent-pipeline {
+  --ap-stagger: 70ms;
+}
+
+.agent-pipeline__step {
+  opacity: 0;
+  animation: agent-pipeline-step-in 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.agent-pipeline__glyph {
+  transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+}
+
+.agent-pipeline__glyph--active {
+  animation: agent-pipeline-ring 2s ease-in-out infinite;
+}
+
+.agent-pipeline__glyph--done .material-symbols-outlined {
+  animation: agent-pipeline-check-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.agent-pipeline__connector {
+  transition: color 0.3s ease, opacity 0.3s ease;
+}
+
+.agent-pipeline__connector--flow {
+  color: var(--secondary);
+}
+
+.agent-pipeline__connector--flow .material-symbols-outlined {
+  animation: agent-pipeline-connector-flow 1.25s ease-in-out infinite;
+}
+
+/* Overview variant: cards */
+.agent-pipeline-overview__card {
+  opacity: 0;
+  animation: agent-pipeline-step-in 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.agent-pipeline-overview__card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 14px rgba(13, 61, 61, 0.08);
+}
+
+.agent-pipeline-overview__icon {
+  display: inline-block;
+  transition: transform 0.35s ease;
+}
+
+.agent-pipeline-overview__card:hover .agent-pipeline-overview__icon {
+  transform: scale(1.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-pipeline__step,
+  .agent-pipeline-overview__card {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .agent-pipeline__glyph--active {
+    animation: none;
+  }
+  .agent-pipeline__connector--flow .material-symbols-outlined {
+    animation: none;
+  }
+  .agent-pipeline__glyph--done .material-symbols-outlined {
+    animation: none;
+  }
+}
+
 ::-webkit-scrollbar { width: 5px; height: 5px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--outline-variant); border-radius: 4px; }
 
-/* Input focus */
-.ent-input:focus { outline: none; border-color: var(--secondary) !important; box-shadow: 0 0 0 3px rgba(0,88,190,0.1); }
+.ent-input:focus {
+  outline: none;
+  border-color: var(--secondary) !important;
+  box-shadow: 0 0 0 3px rgba(13, 115, 119, 0.12);
+}
 .ent-input::placeholder { color: var(--outline); opacity: 0.6; }
-select.ent-input { appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%2375777f' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 12px center; padding-right: 36px !important; }
+select.ent-input {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%236b7280' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 36px !important;
+}
 
-/* Footer link hover */
 .footer-link { transition: color 0.15s; }
 .footer-link:hover { color: var(--primary) !important; }
 .footer-link-danger:hover { color: var(--error) !important; }
+
+/* Main content shifts with sidebar */
+.app-main-shell {
+  transition: margin-left 0.2s ease;
+}
+
+/* Fixed sidebar below header */
+.app-sidebar {
+  position: fixed;
+  left: 0;
+  top: var(--header-height);
+  width: var(--sidebar-width);
+  height: calc(100vh - var(--header-height));
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-container-lowest);
+  border-right: 1px solid var(--border-subtle);
+  transition: width 0.2s ease;
+  overflow: hidden;
+}
+
+.app-sidebar--collapsed {
+  width: 72px;
+}
+
+.app-sidebar--collapsed .app-sidebar__label,
+.app-sidebar--collapsed .nav-link__text,
+.app-sidebar--collapsed .app-sidebar__user-meta,
+.app-sidebar--collapsed .app-sidebar__action-text {
+  display: none;
+}
+
+.app-sidebar--collapsed .nav-link {
+  justify-content: center;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.app-sidebar--collapsed .app-sidebar__user {
+  justify-content: center;
+  margin-bottom: 0.75rem;
+}
+
+.app-sidebar--collapsed .app-sidebar__footer {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.app-sidebar--collapsed .app-sidebar__action {
+  justify-content: center;
+}
+
+.app-sidebar__label {
+  padding: 1.25rem 1.25rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--on-surface-variant);
+}
+
+.app-sidebar__nav {
+  flex: 1;
+  overflow-y: auto;
+  padding-top: 4px;
+}
+
+.app-sidebar__footer {
+  padding: 1rem 1rem 1.25rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.app-sidebar__user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 1rem;
+}
+
+.app-sidebar__user-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--primary-button);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.app-sidebar__user-meta {
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+}
+
+.app-sidebar__user-name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--on-surface);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-sidebar__user-email {
+  font-size: 0.6875rem;
+  color: var(--outline);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-sidebar__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.app-sidebar__action {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px;
+  font-size: 0.8rem;
+  color: var(--on-surface-variant);
+  border-radius: 6px;
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.app-sidebar__action:hover {
+  background: var(--surface-container-high);
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -10,6 +10,10 @@ export default defineConfig({
         target: 'http://localhost:5000',
         changeOrigin: true,
       },
+      '/screenshots': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      },
     },
   },
 });

--- a/start.ps1
+++ b/start.ps1
@@ -156,7 +156,9 @@ $migrations = @(
     "database/migrations/003_test_runs.sql",
     "database/migrations/004_bug_reports.sql",
     "database/migrations/005_not_null_constraints.sql",
-    "database/migrations/006_credentials_text.sql"
+    "database/migrations/006_credentials_text.sql",
+    "database/migrations/007_app_memory.sql",
+    "database/migrations/008_run_status_enum.sql"
 )
 
 # Temporarily allow non-terminating errors so psql NOTICE/WARNING lines on stderr
@@ -402,7 +404,7 @@ try {
         -ContentType "application/json" -Body $body -UseBasicParsing -ErrorAction Stop
     Write-OK "Default account created"
 } catch {
-    $code = $_.Exception.Response.StatusCode.value__
+    $code = if ($_.Exception.Response) { $_.Exception.Response.StatusCode.value__ } else { 0 }
     if ($code -eq 409) {
         Write-OK "Default account already exists"
     } else {

--- a/start.sh
+++ b/start.sh
@@ -371,6 +371,26 @@ if [ -n "$AUTH_TOKEN" ]; then
         '{"username":"admin@juice-sh.op","password":"admin123"}'
     register_app "DVWA" "http://localhost:8080/login.php" \
         '{"username":"admin","password":"password"}'
+
+    # Korn Ferry Talent — SSO (Microsoft Entra IDP)
+    KF_EMAIL="$(read_env_key "$BACKEND/.env" KF_EMAIL)"
+    KF_IDP_PASSWORD="$(read_env_key "$BACKEND/.env" KF_IDP_PASSWORD)"
+    if [ -n "$KF_EMAIL" ] && [ -n "$KF_IDP_PASSWORD" ]; then
+        KF_CREDS=$(printf '%s' "{\"login_flow\":[
+            {\"action\":\"fill\",\"selector\":\"#email-input\",\"value\":\"$KF_EMAIL\"},
+            {\"action\":\"click\",\"selector\":\"#submit-button\"},
+            {\"action\":\"wait_for_navigation\",\"timeout\":15000},
+            {\"action\":\"wait_for_selector\",\"selector\":\"#i0118\",\"timeout\":15000},
+            {\"action\":\"fill\",\"selector\":\"#i0118\",\"value\":\"$KF_IDP_PASSWORD\"},
+            {\"action\":\"click\",\"selector\":\"#idSIButton9\"},
+            {\"action\":\"wait_for_navigation\",\"timeout\":20000}
+        ]}")
+        register_app "Korn Ferry Talent (SSO)" \
+            "https://home.kornferrytalent-dev.com/login" \
+            "$KF_CREDS"
+    else
+        warn "KF_EMAIL or KF_IDP_PASSWORD not set in backend/.env — skipping Korn Ferry app registration"
+    fi
 else
     warn "Could not obtain auth token — skipping sample app registration"
 fi
@@ -392,6 +412,7 @@ echo -e ""
 echo -e "  Sample test sites:"
 echo -e "  Juice Shop   ->  http://localhost:3000  (admin@juice-sh.op / admin123)"
 echo -e "  DVWA         ->  http://localhost:8080  (admin / password)"
+echo -e "  Korn Ferry   ->  https://home.kornferrytalent-dev.com/login  (SSO - set KF_IDP_PASSWORD in backend/.env)"
 echo -e ""
 echo -e "${CYN}  Default BugHunter account:${RST}"
 echo -e "  Email        ->  ${GRN}$DEFAULT_EMAIL${RST}"


### PR DESCRIPTION
Introduce a memory & skills layer so agents get smarter across consecutive
test runs on the same app. Previously every run started from scratch with
zero historical context.

New components:
- database/migrations/007_agent_memory.sql: agent_memory and agent_skills tables
- agent/tools/memory.py: service module for loading/saving memory and skills

Changes to existing pipeline:
- AgentState: new optional fields (memory, skills, app_id)
- runner.py: loads memory before pipeline, saves memory + extracts skills after
- orchestrator.py: plans strategy weighted toward previously buggy areas
- explorer.py: prioritizes visiting pages where bugs were found before
- validator.py: detects regression bugs using historical context
- security.py: tests previously effective payloads first (adaptive payloads)
- reporter.py: flags regressions when fixed bugs reappear

https://claude.ai/code/session_016uapScfiYy7VkVdiuTA77q